### PR TITLE
Fixes pyproject.toml install target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ tracking-client = [
   "pydantic"
 ]
 
-[tool.poetry.packages]
-py_modules = ["burr"]
+[tool.setuptools.packages.find]
+include = ["burr"]
 
 [project.urls]
 Homepage = "https://github.com/dagworks-inc/burr"


### PR DESCRIPTION
When we have extra folders there it fails, this specifies the right one.