### PR TITLE
Removes links to slack

### DIFF
--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -6,9 +6,9 @@ Please read the `code of conduct <https://github.com/dagworks-inc/burr/tree/main
 prior to contributing. Then follow these guidelines:
 
 #. Create a fork of the repository.
-#. Ensure all tests pass
-#. Make a PR to the main repository
-#. Ping one of the maintainers to review your PR (best way to reach us is via the `slack community <https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg>`_)
+#. Ensure all tests pass.
+#. Make a PR to the main repository.
+#. Ping one of the maintainers to review your PR.
 
 -----------------------
 Contribution guidelines

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -6,7 +6,7 @@ Developing / Contributing
 
 Instructions to develop/get started with `Burr`! If you don't know where
 to start, you can always reach out to us:
-- Join our `slack community <https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg>`_
+- Start an issue or discussion on our `GitHub  <https://github.com/dagworks-inc/burr>`_.
 - Reach out to us by `email  <mailto:founders@dagworks.io>`_
 
 .. toctree::

--- a/docs/main.rst
+++ b/docs/main.rst
@@ -12,5 +12,6 @@ You'll find this documentation separated into three sections.
 
 We also ask that you:
 
-- Join the `Hamilton slack <https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg>`_ (currently we're combining the help-channel for the two products)
+- Report any bugs, issues, or feature requests via `GitHub Issues <https://github.com/DAGWorks-Inc/burr/issues>`_ or
+`GitHub Discussions <https://github.com/DAGWorks-Inc/burr/discussions>`_.
 - Give us a star on `GitHub <https://github.com/dagworks-inc/burr>`_ if you like the project!

--- a/telemetry/ui/src/components/nav/appcontainer.tsx
+++ b/telemetry/ui/src/components/nav/appcontainer.tsx
@@ -83,7 +83,7 @@ export const AppContainer = (props: { children: React.ReactNode }) => {
     },
     {
       name: 'Get Help',
-      href: 'https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg',
+      href: 'https://github.com/DAGWorks-Inc/burr/discussions',
       icon: ChatBubbleLeftEllipsisIcon,
       linkType: 'external'
     }


### PR DESCRIPTION
Since we haven't decided where to put the community. Pushing to github discussions instead.