### PR TITLE
Fixes a typo with the wrong state in local tracking client

### DIFF
--- a/burr/tracking/client.py
+++ b/burr/tracking/client.py
@@ -341,7 +341,7 @@ class LocalTrackingClient(
             "position": position,
             "state": State(prior_state),
             "created_at": datetime.datetime.fromtimestamp(os.path.getctime(path)).isoformat(),
-            "status": "success" if line["exception"] is None else "failed",
+            "status": "completed" if line["exception"] is None else "failed",
         }
 
 


### PR DESCRIPTION
We have not added a test but we plan to at some point -- this is solidly power-user mode.