### PR TITLE
Makes the key headers standout

### DIFF
--- a/telemetry/ui/src/components/routes/app/DataView.tsx
+++ b/telemetry/ui/src/components/routes/app/DataView.tsx
@@ -35,7 +35,7 @@ export const DataView = (props: { currentStep: Step | undefined; priorStep: Step
   return (
     <div className="pl-1 flex flex-col gap-2 hide-scrollbar">
       <div className="flex flex-row justify-between sticky top-0 z-20 bg-white">
-        <h1 className="text-2xl text-black-1000 font-semibold pt-2">State</h1>
+        <h1 className="text-2xl text-gray-900 font-semibold pt-2">State</h1>
         <div className="flex flex-row justify-end gap-2 pr-2">
           <SwitchField>
             <Switch
@@ -73,19 +73,19 @@ export const DataView = (props: { currentStep: Step | undefined; priorStep: Step
       <StateView stateData={stateData} viewRawData={viewRawData} />
       {error && (
         <>
-          <h1 className="text-2xl text-black-1000 font-semibold">Error</h1>
+          <h1 className="text-2xl text-gray-900 font-semibold">Error</h1>
           <ErrorView error={error} />
         </>
       )}
       {resultData && Object.keys(resultData).length > 0 && (
         <>
-          <h1 className="text-2xl text-black-1000 font-semibold sticky top-8 bg-white">Result</h1>
+          <h1 className="text-2xl text-gray-900 font-semibold sticky top-8 bg-white">Result</h1>
           <ResultView resultData={resultData} viewRawData={viewRawData} />
         </>
       )}
       {inputs && Object.keys(inputs).length > 0 && (
         <>
-          <h1 className="text-2xl text-black-1000 font-semibold sticky top-8 bg-white">Input</h1>
+          <h1 className="text-2xl text-gray-900 font-semibold sticky top-8 bg-white">Input</h1>
           <InputsView inputs={inputs || {}} />
         </>
       )}
@@ -149,7 +149,7 @@ const Header = (props: {
 
   return (
     <div className="flex flex-row gap-1 z-10 pb-2 items-center">
-      <h1 className="text-lg text-black-900 font-semibold text-under">{props.name}</h1>
+      <h1 className="text-lg text-gray-900 font-semibold text-under">{props.name}</h1>
       <MinimizeMaximizeIcon
         className={classNames(
           'text-gray-500',

--- a/telemetry/ui/src/components/routes/app/DataView.tsx
+++ b/telemetry/ui/src/components/routes/app/DataView.tsx
@@ -35,7 +35,7 @@ export const DataView = (props: { currentStep: Step | undefined; priorStep: Step
   return (
     <div className="pl-1 flex flex-col gap-2 hide-scrollbar">
       <div className="flex flex-row justify-between sticky top-0 z-20 bg-white">
-        <h1 className="text-2xl text-gray-600 font-semibold pt-2">State</h1>
+        <h1 className="text-2xl text-black-1000 font-semibold pt-2">State</h1>
         <div className="flex flex-row justify-end gap-2 pr-2">
           <SwitchField>
             <Switch
@@ -73,19 +73,19 @@ export const DataView = (props: { currentStep: Step | undefined; priorStep: Step
       <StateView stateData={stateData} viewRawData={viewRawData} />
       {error && (
         <>
-          <h1 className="text-2xl text-gray-600 font-semibold">Error</h1>
+          <h1 className="text-2xl text-black-1000 font-semibold">Error</h1>
           <ErrorView error={error} />
         </>
       )}
       {resultData && Object.keys(resultData).length > 0 && (
         <>
-          <h1 className="text-2xl text-gray-600 font-semibold sticky top-8 bg-white">Result</h1>
+          <h1 className="text-2xl text-black-1000 font-semibold sticky top-8 bg-white">Result</h1>
           <ResultView resultData={resultData} viewRawData={viewRawData} />
         </>
       )}
       {inputs && Object.keys(inputs).length > 0 && (
         <>
-          <h1 className="text-2xl text-gray-600 font-semibold sticky top-8 bg-white">Input</h1>
+          <h1 className="text-2xl text-black-1000 font-semibold sticky top-8 bg-white">Input</h1>
           <InputsView inputs={inputs || {}} />
         </>
       )}
@@ -149,7 +149,7 @@ const Header = (props: {
 
   return (
     <div className="flex flex-row gap-1 z-10 pb-2 items-center">
-      <h1 className="text-lg text-gray-500 font-semibold text-under">{props.name}</h1>
+      <h1 className="text-lg text-black-900 font-semibold text-under">{props.name}</h1>
       <MinimizeMaximizeIcon
         className={classNames(
           'text-gray-500',


### PR DESCRIPTION
It's hard to quickly scroll and see the headlines. Went with a conservative black, rather than green
or something.

## Changes
 - data view headers should now stand out

Before:
![Screen Shot 2024-04-07 at 2 08 33 PM](https://github.com/DAGWorks-Inc/burr/assets/2328071/f1243d8f-6144-4d9f-a48c-9152a9c5e012)

After:
![Screen Shot 2024-04-07 at 2 08 00 PM](https://github.com/DAGWorks-Inc/burr/assets/2328071/e38f42d7-895e-44de-aa6b-cb44471452cd)



## How I tested this
 - locally

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
