### PR TITLE
Handling case when state is None

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -1058,6 +1058,8 @@ class Application:
             self._state = self._state.update(**{SEQUENCE_ID: self.sequence_id + 1})
 
     def _set_sequence_id(self, sequence_id: int):
+        if self._state is None:
+            self._state = State() #ideally we copy the default state
         self._state = self._state.update(**{SEQUENCE_ID: sequence_id})
 
     @property


### PR DESCRIPTION
I created a custom presister for Postgres and was getting this:

```python
    presister = PostgreSQLPersister()
    presister.initialize()
    return ApplicationBuilder().with_actions(
        human_input=human_input,
    ).with_transitions(

    ).initialize_from(
            initializer=presister,
            resume_at_next_action=True,
            default_state={"chat_history": []},
            default_entrypoint="human_input"
    ).with_state_persister(
        presister
    ).with_identifiers(
        app_id=f"{custormer_id}", partition_key=str(pk)
    ).build()
```

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
