### PR TITLE
Adds guard for persisters returning bad state

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -1404,6 +1404,14 @@ class ApplicationBuilder:
             self.state = self.state.update(**self.default_state)
             self.sequence_id = None  # has to start at None
         else:
+            if load_result["state"] is None:
+                raise ValueError(
+                    f"Error: {self.initializer.__class__.__name__} returned {load_result} for "
+                    f"partition_key:{self.partition_key}, app_id:{self.app_id}, "
+                    f"sequence_id:{self.sequence_id}, "
+                    f"but state was None! This is not allowed. Please return None in this case, or double "
+                    f"check that persisted state can never be a None value."
+                )
             # there was something
             last_position = load_result["position"]
             self.state = load_result["state"]


### PR DESCRIPTION
The entire call from load_state should be None if something isn't found.

Otherwise the persister should fix its assumptions/make sure None state is not saved.

## Changes
 - ApplicationBuilder code
 - test for it

## How I tested this
 - locally

## Notes
 - Spurred by discussion in #146 

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
