### PR TITLE
Drops rendering numeric arrays

### DIFF
--- a/telemetry/ui/src/components/routes/app/DataView.tsx
+++ b/telemetry/ui/src/components/routes/app/DataView.tsx
@@ -290,6 +290,10 @@ const RenderedField = (props: {
                 <span>NULL</span>
               ) : (
                 Object.entries(value).map(([k, v]) => {
+                  if (v instanceof Array && v.length > 0 && typeof v[0] === 'number') {
+                    // we want to display arrays of numbers as a single string.
+                    v = v.toString();
+                  }
                   return (
                     <div key={key + '-' + k} className={bodyClassNames}>
                       <RenderedField
@@ -328,6 +332,10 @@ const FormRenderer: React.FC<FormRendererProps> = ({ data, isDefaultExpanded: is
     return (
       <>
         {Object.entries(data).map(([key, value]) => {
+          if (value instanceof Array && value.length > 0 && typeof value[0] === 'number') {
+            // we want to display arrays of numbers as a single string.
+            value = value.toString();
+          }
           return (
             <RenderedField
               keyName={key}


### PR DESCRIPTION
Why? because they can be large and cause the UI to slow down.

Moreover it's likely not that useful to render them directly. The JSON view is probably better for that.

Before:
![Screen Shot 2024-04-08 at 3 06 46 PM](https://github.com/DAGWorks-Inc/burr/assets/2328071/e26a8630-2769-4772-b4f1-0330f138dd60)


After:
![Screen Shot 2024-04-08 at 3 37 32 PM](https://github.com/DAGWorks-Inc/burr/assets/2328071/a70d09bd-53de-46f2-bd26-03c06cd43dbb)

![Screen Shot 2024-04-08 at 3 31 06 PM](https://github.com/DAGWorks-Inc/burr/assets/2328071/4136a4c5-05fa-4fd6-89b5-63ba9ae473eb)


## Changes
- DataView

## How I tested this
- locally

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
