### PR TITLE
Fixes issues with streaming + sequence ID

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -858,7 +858,10 @@ class Application:
             state=self._state,
             inputs=inputs,
             sequence_id=self.sequence_id,
+            app_id=self._uid,
+            partition_key=self._partition_key,
         )
+
         # we need to track if there's any exceptions that occur during this
         try:
 
@@ -871,10 +874,11 @@ class Application:
                 result: Optional[dict],
                 state: State,
                 exc: Optional[Exception] = None,
-                # seq_id=self.sequence_id,
             ):
                 self._adapter_set.call_all_lifecycle_hooks_sync(
                     "post_run_step",
+                    app_id=self._uid,
+                    partition_key=self._partition_key,
                     action=next_action,
                     state=state,
                     result=result,
@@ -889,6 +893,8 @@ class Application:
                 action, result, state = self._step(inputs=inputs, _run_hooks=False)
                 self._adapter_set.call_all_lifecycle_hooks_sync(
                     "post_run_step",
+                    app_id=self._uid,
+                    partition_key=self._partition_key,
                     action=next_action,
                     state=self._state,
                     result=result,
@@ -917,6 +923,8 @@ class Application:
             # block of the streaming result container
             self._adapter_set.call_all_lifecycle_hooks_sync(
                 "post_run_step",
+                app_id=self._uid,
+                partition_key=self._partition_key,
                 action=next_action,
                 state=self._state,
                 result=None,


### PR DESCRIPTION
https://github.com/DAGWorks-Inc/burr/issues/177

This ensures the following:

1. That increment_sequence_id is always called first
2. That it is only called once
3. That all pre run step hooks are called only once
4. That all post run step hooks are called only once

We'll likely want to improve this, the control flow is complex.

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
