### PR TITLE
Fixes wording in install docs

### DIFF
--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -4,7 +4,7 @@ Installing
 
 Burr itself requires almost no dependencies. Every *extra*/*plugin* is an additional install target.
 
-We recommend you start with installing the ``learn`` target -- this has dependencies necessary to track burr through the UI,
+We recommend you start with installing the ``start`` target -- this has dependencies necessary to track burr through the UI,
 along with a fully built server.
 
 .. code-block:: bash


### PR DESCRIPTION
Start is the target, not learn.

## Changes
 - install docs page

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
