### PR TITLE
Adds ability for action to specify its own source code

### DIFF
--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -170,6 +170,13 @@ class Action(Function, Reducer, abc.ABC):
     def streaming(self) -> bool:
         return False
 
+    def get_source(self) -> str:
+        """Returns the source code of the action. This will default to
+        the source code of the class in which the action is implemented,
+        but can be overwritten." Override if you want debugging/tracking
+        to display a different source"""
+        return inspect.getsource(self.__class__)
+
     def __repr__(self):
         read_repr = ", ".join(self.reads) if self.reads else "{}"
         write_repr = ", ".join(self.writes) if self.writes else "{}"
@@ -538,6 +545,10 @@ class FunctionBasedAction(SingleStepAction):
 
     def is_async(self) -> bool:
         return inspect.iscoroutinefunction(self._fn)
+
+    def get_source(self) -> str:
+        """Return the source of the code for this action."""
+        return inspect.getsource(self._fn)
 
 
 StreamType = Tuple[dict, Optional[State]]
@@ -983,6 +994,10 @@ class FunctionBasedStreamingAction(SingleStepStreamingAction):
 
     def is_async(self) -> bool:
         return inspect.isasyncgenfunction(self._fn)
+
+    def get_source(self) -> str:
+        """Return the source of the code for this action"""
+        return inspect.getsource(self._fn)
 
 
 def _validate_action_function(fn: Callable):

--- a/burr/tracking/common/models.py
+++ b/burr/tracking/common/models.py
@@ -1,12 +1,10 @@
 import datetime
-import inspect
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import field_serializer
 
 from burr.common import types as burr_types
 from burr.core import Action
-from burr.core.action import FunctionBasedAction, FunctionBasedStreamingAction
 from burr.core.application import ApplicationGraph, Transition
 from burr.integrations.base import require_plugin
 
@@ -52,10 +50,7 @@ class ActionModel(IdentifyingModel):
         :param action: Action to create the model from
         :return:
         """
-        if isinstance(action, (FunctionBasedAction, FunctionBasedStreamingAction)):
-            code = inspect.getsource(action.fn)
-        else:
-            code = inspect.getsource(action.__class__)
+        code = action.get_source()  # delegate to the action
         optional_inputs, required_inputs = action.optional_and_required_inputs
         return ActionModel(
             name=action.name,

--- a/tests/tracking/test_common_models.py
+++ b/tests/tracking/test_common_models.py
@@ -1,0 +1,29 @@
+from burr.core import Action, State
+from burr.tracking.common.models import ActionModel
+
+
+class ActionWithCustomSource(Action):
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def reads(self) -> list[str]:
+        return []
+
+    def run(self, state: State, **run_kwargs) -> dict:
+        return {}
+
+    @property
+    def writes(self) -> list[str]:
+        return []
+
+    def update(self, result: dict, state: State) -> State:
+        return state
+
+    def get_source(self) -> str:
+        return "custom source code"
+
+
+def test_action_with_custom_source():
+    model = ActionModel.from_action(ActionWithCustomSource().with_name("foo"))
+    assert model.code == "custom source code"


### PR DESCRIPTION
This enables people to build classes that have different sources (E.G. function wrappers)

## Changes
- added the `def get_source_code()` function

## How I tested this
- unit test + manually

## Notes
- We'll want to do this with Hamilton + langchain

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
