### PR TITLE
Fixes picking up from null sequence ID

### DIFF
--- a/burr/tracking/client.py
+++ b/burr/tracking/client.py
@@ -326,8 +326,6 @@ class LocalTrackingClient(
         # TODO:
         if app_id is None:
             return  # no application ID
-        if sequence_id is None:
-            sequence_id = -1  # get the last one
         path = os.path.join(self.storage_dir, app_id, self.LOG_FILENAME)
         if not os.path.exists(path):
             return None
@@ -339,10 +337,16 @@ class LocalTrackingClient(
         json_lines = [json.loads(js_line) for js_line in json_lines]
         # filter to only end_entry
         line = None
-        for js_line in json_lines:
-            if js_line["type"] == "end_entry":
-                if js_line["sequence_id"] == sequence_id:
-                    line = js_line
+        if sequence_id is None:
+            # get the last one, we want to start at the end
+            line = json_lines[-1]
+            sequence_id = line["sequence_id"]
+        else:
+            for js_line in json_lines:
+                if js_line["type"] == "end_entry":
+                    if js_line["sequence_id"] == sequence_id:
+                        line = js_line
+
         if line is None:
             raise ValueError(
                 f"Sequence number {sequence_id} not found for {self.project_id}/{app_id}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [

--- a/tests/tracking/test_local_tracking_client.py
+++ b/tests/tracking/test_local_tracking_client.py
@@ -284,3 +284,16 @@ def test_multi_fork_tracking_client(tmpdir):
 
     assert forked_app_2.parent_pointer.app_id == forked_app_id
     assert forked_app_2.parent_pointer.sequence_id == 10
+
+    # fork from latest
+    # TODO -- break this up -- this test tests too much at once
+    # This is a quick addition to test that forking from sequence_id=None picks up where the last one left off
+
+    forked_forked_forked_app_id = f"fork_3_{common_app_id}"
+    forked_app_3, tracker = create_application(
+        forked_forked_app_id, forked_forked_forked_app_id, None, max_count=35
+    )
+    assert (
+        forked_app_3.sequence_id == forked_app_2.sequence_id == 25
+    )  # this should pick up where the last one left off
+    assert forked_app_3.parent_pointer.app_id == forked_forked_app_id


### PR DESCRIPTION
This was an error case. We're fixing it. We used to look for ID -1, but this ensures that the path with local tracking client works as well for null, and doesn't try to find -1.