### PR TITLE
Adds docs on running burr server in google collab

### DIFF
--- a/docs/concepts/tracking.rst
+++ b/docs/concepts/tracking.rst
@@ -84,3 +84,21 @@ run it with the following command:
     burr
 
 This will start a server on port 7241, and open up a browser window with the UI for you to explore.
+
+
+Using Burr in Google Collab
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you run Burr in Google Collab, you can use the following code to expose the Burr UI to your browser:
+
+.. code-block:: python
+
+    # in one cell - expose the port:
+    from google.colab import output
+    output.serve_kernel_port_as_window(7241)
+
+.. code-block:: python
+
+    # in another cell - start burr: (! denotes a command line call)
+    !burr &
+    # now click the localhost:7241 from the prior cell.
+    # It should open up a new tab with the burr UI!


### PR DESCRIPTION
How to expose the port, etc.

## Changes
 - docs

## How I tested this
- on google collab
- locally for docs to render

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
