### PR TITLE
Removes `state` from persister primary key

### DIFF
--- a/burr/core/persistence.py
+++ b/burr/core/persistence.py
@@ -166,7 +166,7 @@ class SQLLitePersister(BaseStatePersister):
                 status TEXT NOT NULL,
                 state TEXT NOT NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (partition_key, app_id, sequence_id, position, state)
+                PRIMARY KEY (partition_key, app_id, sequence_id, position)
             )"""
         )
         cursor.execute(

--- a/burr/integrations/persisters/postgresql.py
+++ b/burr/integrations/persisters/postgresql.py
@@ -100,7 +100,7 @@ class PostgreSQLPersister(persistence.BaseStatePersister):
                 status TEXT NOT NULL,
                 state JSONB NOT NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (partition_key, app_id, sequence_id, position, state)
+                PRIMARY KEY (partition_key, app_id, sequence_id, position)
             )"""
         )
         cursor.execute(


### PR DESCRIPTION
This really shouldn't have been there in the first place.
