### PR TITLE
Local tracker encoding fix

### DIFF
--- a/burr/tracking/client.py
+++ b/burr/tracking/client.py
@@ -221,7 +221,7 @@ class LocalTrackingClient(
             # currently we write start events, so it really won't matter
             # but in the future we'll write end events, but we'll parse it in a
             # way that allows them to be interwoven
-            with open(parent_children_list_path, "a") as f:
+            with open(parent_children_list_path, "a", errors="replace", encoding="utf-8") as f:
                 fileno = f.fileno()
                 try:
                     fcntl.flock(fileno, fcntl.LOCK_EX)
@@ -257,7 +257,7 @@ class LocalTrackingClient(
         path = os.path.join(cls.get_storage_path(project, storage_dir), app_id, cls.LOG_FILENAME)
         if not os.path.exists(path):
             return False
-        lines = open(path, "r").readlines()
+        lines = open(path, "r", errors="replace", encoding="utf-8").readlines()
         if len(lines) == 0:
             return False
         return True
@@ -292,7 +292,7 @@ class LocalTrackingClient(
         path = os.path.join(cls.get_storage_path(project, storage_dir), app_id, cls.LOG_FILENAME)
         if not os.path.exists(path):
             raise ValueError(f"No logs found for {project}/{app_id} under {storage_dir}")
-        with open(path, "r") as f:
+        with open(path, "r", errors="replace", encoding="utf-8") as f:
             json_lines = f.readlines()
         # load as JSON
         json_lines = [json.loads(js_line) for js_line in json_lines]
@@ -369,7 +369,7 @@ class LocalTrackingClient(
             parent_pointer=PointerModel.from_pointer(parent_pointer),
             spawning_parent_pointer=PointerModel.from_pointer(spawning_parent_pointer),
         ).model_dump()
-        with open(metadata_path, "w", errors="replace") as f:
+        with open(metadata_path, "w", errors="replace", encoding="utf-8") as f:
             json.dump(metadata, f)
 
         # Append to the parents of this the pointer to this, now
@@ -471,7 +471,7 @@ class LocalTrackingClient(
         path = os.path.join(self.storage_dir, app_id, self.LOG_FILENAME)
         if not os.path.exists(path):
             return None
-        with open(path, "r") as f:
+        with open(path, "r", errors="replace", encoding="utf-8") as f:
             json_lines = f.readlines()
         if len(json_lines) == 0:
             return None  # in this case we have not logged anything yet

--- a/docs/concepts/state-persistence.rst
+++ b/docs/concepts/state-persistence.rst
@@ -26,6 +26,11 @@ and you want to store the state of the process after each action, and then reloa
 
 ``Burr`` provides a few simple interfaces to do this with minimal changes. Let's walk through a simple chatbot example as we're explaining concepts:
 
+Two notable assumptions:
+
+1. for library provided persisters, state needs to ultimately be JSON serializable. If it's not, you can use the :doc:`serde` API to customize serialization and deserialization.
+2. your general assumption should be that strings are/will be encoded as UTF-8, however this is dependent on the persister you use.
+
 State Keys
 ----------
 Burr `applications` are, by default, keyed on two entities:


### PR DESCRIPTION
The local tracker was encoding writes, but not reads. This fixes https://github.com/DAGWorks-Inc/burr/issues/273.

On different python systems, the default encoding is different, and thus we
weren't consistent here.

This change makes sure all local tracker reads and writes use the utf-8 encoding.
We also skip character errors where appropriate.


## Changes
 - local tracker
 - docs
 - local tracker test

## How I tested this
- locally
- user tested RC version.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
