### PR TITLE
Adds option to remove thread check on sqlite persister for streamlit

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -561,7 +561,8 @@ class Application:
             return next_action, result, new_state
 
     def reset_to_entrypoint(self) -> None:
-        """Resets the state machine to the entrypoint action."""
+        """Resets the state machine to the entrypoint action -- you probably want to consider having a loop
+        in your graph, but this will do the trick if you need it!"""
         self._set_state(self._state.wipe(delete=[PRIOR_STEP]))
 
     def _update_internal_state_value(self, new_state: State, next_action: Action) -> State:

--- a/burr/core/persistence.py
+++ b/burr/core/persistence.py
@@ -142,16 +142,26 @@ class SQLLitePersister(BaseStatePersister):
 
     PARTITION_KEY_DEFAULT = ""
 
-    def __init__(self, db_path: str, table_name: str = "burr_state", serde_kwargs: dict = None):
+    def __init__(
+        self,
+        db_path: str,
+        table_name: str = "burr_state",
+        serde_kwargs: dict = None,
+        connect_kwargs: dict = None,
+    ):
         """Constructor
 
         :param db_path: the path the DB will be stored.
         :param table_name: the table name to store things under.
         :param serde_kwargs: kwargs for state serialization/deserialization.
+        :param connect_kwargs: kwargs to pass to the sqlite3.connect method.
+            Use check_same_thread=False to enable use ina  multithreaded context
         """
         self.db_path = db_path
         self.table_name = table_name
-        self.connection = sqlite3.connect(db_path)
+        self.connection = sqlite3.connect(
+            db_path, **connect_kwargs if connect_kwargs is not None else {}
+        )
         self.serde_kwargs = serde_kwargs or {}
 
     def create_table_if_not_exists(self, table_name: str):

--- a/examples/hello-world-counter/application.py
+++ b/examples/hello-world-counter/application.py
@@ -24,7 +24,7 @@ def application(
     storage_dir: Optional[str] = "~/.burr",
     hooks: Optional[List[LifecycleAdapter]] = None,
 ) -> Application:
-    persister = SQLLitePersister("demos.db", "counter")
+    persister = SQLLitePersister("demos.db", "counter", connect_kwargs={"check_same_thread": False})
     persister.initialize()
     logger.info(
         f"{partition_key} has these prior invocations: {persister.list_app_ids(partition_key)}"

--- a/examples/hello-world-counter/streamlit_app.py
+++ b/examples/hello-world-counter/streamlit_app.py
@@ -22,6 +22,7 @@ def counter_view(app_state: AppState):
             set_slider_to_current()
         else:
             application.update_state(application.state.update(counter=0))
+            application.reset_to_entrypoint()
             action, result, state = application.step()
             app_state.history.append(Record(state.get_all(), action.name, result))
 


### PR DESCRIPTION
Streamlit uses multiple threads for execution, which can mess with the sqlite persister, which wants to be all on the same thread. This allows it to bypass the thread check with an option.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
