### PR TITLE
Logs attributes

### DIFF
--- a/burr/lifecycle/base.py
+++ b/burr/lifecycle/base.py
@@ -191,6 +191,44 @@ class PreStartSpanHookAsync(abc.ABC):
         pass
 
 
+@lifecycle.base_hook("do_log_attributes")
+class DoLogAttributeHook(abc.ABC):
+    """Hook that is responsible for logging attributes,
+    called by the tracer."""
+
+    @abc.abstractmethod
+    def do_log_attributes(
+        self,
+        *,
+        attributes: Dict[str, Any],
+        action: str,
+        action_sequence_id: int,
+        span: Optional["ActionSpan"],
+        tags: dict,
+        **future_kwargs: Any,
+    ):
+        pass
+
+
+@lifecycle.base_hook("do_log_attributes")
+class DoLogAttributeHookAsync(abc.ABC):
+    """Hook that runs after a span is ended in the tracing API.
+    This can be either a context manager or a logger."""
+
+    @abc.abstractmethod
+    async def do_log_attributes(
+        self,
+        *,
+        attributes: Dict[str, Any],
+        action: str,
+        action_sequence_id: int,
+        span: "ActionSpan",
+        tags: dict,
+        **future_kwargs: Any,
+    ):
+        pass
+
+
 @lifecycle.base_hook("post_end_span")
 class PostEndSpanHook(abc.ABC):
     """Hook that runs after a span is ended in the tracing API.

--- a/burr/tracking/client.py
+++ b/burr/tracking/client.py
@@ -80,7 +80,7 @@ def _filter_inputs(d: dict) -> dict:
 
 
 def _allowed_project_name(project_name: str, on_windows: bool) -> bool:
-    allowed_chars = "a-zA-Z0-9_\-"
+    allowed_chars = r"a-zA-Z0-9_\-"
     if not on_windows:
         allowed_chars += ":"
     pattern = f"^[{allowed_chars}]+$"

--- a/burr/tracking/common/models.py
+++ b/burr/tracking/common/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from burr.common import types as burr_types
 from burr.core import Action
@@ -191,3 +191,16 @@ class EndSpanModel(IdentifyingModel):
     @property
     def sequence_id(self) -> int:
         return self.action_sequence_id
+
+
+class AttributeModel(IdentifyingModel):
+    """Represents a logged artifact"""
+
+    key: str
+    action_sequence_id: int
+    span_id: Optional[
+        str
+    ]  # It doesn't have to relate to a span, it can be at the level of an action as well
+    value: Union[dict, str, int, float, bool, list, None]
+    tags: Dict[str, str]
+    type: str = "attribute"

--- a/burr/tracking/server/schema.py
+++ b/burr/tracking/server/schema.py
@@ -7,6 +7,7 @@ from pydantic import fields
 
 from burr.tracking.common.models import (
     ApplicationModel,
+    AttributeModel,
     BeginEntryModel,
     BeginSpanModel,
     ChildApplicationModel,
@@ -68,6 +69,7 @@ class Step(pydantic.BaseModel):
     step_start_log: BeginEntryModel
     step_end_log: Optional[EndEntryModel]
     spans: List[Span]
+    attributes: List[AttributeModel]
 
     @staticmethod
     def from_logs(log_lines: List[bytes]) -> List["Step"]:

--- a/burr/visibility/tracing.py
+++ b/burr/visibility/tracing.py
@@ -210,9 +210,22 @@ class ActionSpanTracer(AbstractContextManager, AbstractAsyncContextManager):
         return None
 
     def log_attribute(self, key: str, value: Any):
+        """Logs a single attribute to the UI. Note that this must
+        be paired with a tracker or a tracking hook to be useful, otherwise it
+        will be a no-op.
+
+        :param key: Name of the attribute (must be unique per action/span)
+        :param value: Value of the attribute.
+        """
         self.log_attributes(**{key: value})
 
     def log_attributes(self, **attributes):
+        """Logs a set of attributes to the UI. Note that this must
+        be paired with a tracker or a tracking hook to be useful, otherwise it
+        will be a no-op.
+
+        :param attributes: Attributes to log
+        """
         self.lifecycle_adapters.call_all_lifecycle_hooks_sync(
             "do_log_attributes",
             attributes=attributes,

--- a/docs/concepts/additional-visibility.rst
+++ b/docs/concepts/additional-visibility.rst
@@ -17,7 +17,7 @@ the `OpenTelemetry <https://opentelemetry.io/>`_ sdk, although it is simplified 
 To add the tracing capability, the action first has to declare a ``__tracer`` input. This is a
 an object that instantiates spans and tracks state.
 
-Then, using the `__tracer` as a callable, you can instantiate spans and track state.
+Then, using the ``__tracer`` as a callable, you can instantiate spans and track state.
 
 For the function-based API, this would look as follows:
 
@@ -26,22 +26,23 @@ For the function-based API, this would look as follows:
     from burr.visibility import TracingFactory
     from burr.core import action
 
-    @action(reads=['input_var'], writes=['output_var'])
+    @action(reads=['prompt'], writes=['response'])
     def my_action(state: State, __tracer: TracingFactory) -> State:
-        with __tracer('process_data'):
-            initial_data = _process_data(state['input_var'])
-            with __tracer('validate_data'):
-                _validate(initial_data)
-        with __tracer('transform_data', dependencies=['process_data']):
-            transformed_data = _transform(initial_data)
-        return state.update({'output_var': transformed_data})
+        with __tracer('create_prompt'):
+            modified_prompt = _modify_prompt(state["prompt"])
+            with __tracer('check_prompt_safety'):
+                if _is_unsafe(modified_prompt):
+                    modified_prompt = _fix(modified_prompt)
+        with __tracer('call_llm', dependencies=['create_prompt']):
+            response = _query(prompt=modified_prompt)
+        return state.update({'response': response})
 
 
 This would create the following traces:
 
-#. ``process_data``
-#. ``validate_data`` as a child of ``process_data``
-#. ``transform_data`` as a causal dependent of ``process_data``
+#. ``create_prompt``
+#. ``check_prompt_safety`` as a child of ``create_prompt``
+#. ``call_llm`` as a causal dependent of ``create_prompt``
 
 Dependencies are used to express [dag](-style structures of spans within actions. This is useful for gaining visibility into the internal structure
 of an action, but is likely best used with integrations with micro-orchestration systems for implementating actions, such as Hamilton or Lanchain.
@@ -62,33 +63,35 @@ These just function as callbacks (on enter/exit). The :py:class:`LocalTrackingCl
 Observations
 ------------
 
-(This is a work in progress, and is not complete)
+You can make observations on the state by calling out to the :py:meth:`log_attribute <burr.visibility.ActionSpanTracer.log_attribute>` or :py:meth:`log_attributes <burr.visibility.ActionSpanTracer.log_attributes>` method on the ``__tracer`` context manager
+or the root tracer factory.
 
-You can make observations on the state by calling out to the `log_artifact` method on the `__tracer` context manager.
+This allows you to log any arbitrary observations (think token count prompt, whatnot) that may not be part of state/results.
+
 For instance:
 
 .. code-block:: python
 
-    from burr.visibility import TracingFactory, ArtifactLogger
+    from burr.visibility import TracingFactory
     from burr.core import action
 
-    @action(reads=['input_var'], writes=['output_var'])
-    def my_action(
-        state: State,
-        __tracer: TracingFactory,
-        __logger: ArtifactLogger
-        ) -> State:
-        with __tracer('process_data'):
-            initial_data = _process_data(state['input_var'])
-            with __tracer('validate_data'):
-                validation_results = _validate(initial_data)
-                t.log_artifact(validation_results=validation_results)
-        with __tracer('transform_data', dependencies=['process_data'])
-            transformed_data = _transform(initial_data)
-            __logger.log_artifact(transformed_data_size=len(transformed_data))
+    @action(reads=['prompt'], writes=['response'])
+    def my_action(state: State, __tracer: TracingFactory) -> State:
+        __tracer.log_attribute(prompt_length=len(state["prompt"]), prompt=state["prompt"])
+        with __tracer('create_prompt') as t:
+            modified_prompt = _modify_prompt(state["prompt"])
+            t.log_attribute(modified_prompt=modified_prompt)
+            with __tracer('check_prompt_safety') as t:
+                if is_unsafe:=_is_unsafe(modified_prompt):
+                    modified_prompt = _fix(modified_prompt)
+                t.log_attribute(fixed_prompt=modified_prompt, is_unsafe=is_unsafe)
+        with __tracer('call_llm', dependencies=['create_prompt']):
+            response = _query(prompt=modified_prompt)
+            t.log_attribute(response=response.message, tokens=response.tokens)
+        return state.update({'response': response.message})
 
-        return state.update(output_var=transformed_data)
+The above will log quite a few attributes, prompt length, response tokens, etc... The observation can be any serializable object.
 
-The output can be any "json-dumpable" object (or pydantic model). This will be stored along with the span and can be used for debugging or analysis.
+Note that we are currently building out the capability to wrap a class and "auto-log" standard attributes.
 
 You can read more in the :ref:`reference documentation <visibility>`.

--- a/telemetry/ui/src/api/index.ts
+++ b/telemetry/ui/src/api/index.ts
@@ -11,6 +11,7 @@ export type { ActionModel } from './models/ActionModel';
 export type { ApplicationLogs } from './models/ApplicationLogs';
 export type { ApplicationModel } from './models/ApplicationModel';
 export type { ApplicationSummary } from './models/ApplicationSummary';
+export type { AttributeModel } from './models/AttributeModel';
 export type { BackendSpec } from './models/BackendSpec';
 export type { BeginEntryModel } from './models/BeginEntryModel';
 export type { BeginSpanModel } from './models/BeginSpanModel';

--- a/telemetry/ui/src/api/models/AttributeModel.ts
+++ b/telemetry/ui/src/api/models/AttributeModel.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Represents a logged artifact
+ */
+export type AttributeModel = {
+  type?: string;
+  key: string;
+  action_sequence_id: number;
+  span_id: string | null;
+  value: Record<string, any> | string | number | boolean | null;
+  tags: Record<string, string>;
+};

--- a/telemetry/ui/src/api/models/Step.ts
+++ b/telemetry/ui/src/api/models/Step.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AttributeModel } from './AttributeModel';
 import type { BeginEntryModel } from './BeginEntryModel';
 import type { EndEntryModel } from './EndEntryModel';
 import type { Span } from './Span';
@@ -9,8 +10,8 @@ import type { Span } from './Span';
  * Log of  astep -- has a start and an end.
  */
 export type Step = {
-    step_start_log: BeginEntryModel;
-    step_end_log: (EndEntryModel | null);
-    spans: Array<Span>;
+  step_start_log: BeginEntryModel;
+  step_end_log: EndEntryModel | null;
+  spans: Array<Span>;
+  attributes: Array<AttributeModel>;
 };
-

--- a/telemetry/ui/src/components/routes/app/StateMachine.tsx
+++ b/telemetry/ui/src/components/routes/app/StateMachine.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { ApplicationModel, Step } from '../../../api';
 import { Tabs } from '../../common/tabs';
 import { DataView } from './DataView';
@@ -11,10 +10,11 @@ export const AppStateView = (props: {
   highlightedActions: Step[] | undefined;
   hoverAction: Step | undefined;
   currentSequenceID: number | undefined;
-  displayGraphAsTab: boolean; // for sideways view
+  currentTab: string;
+  setCurrentTab: (tab: string) => void;
+  displayGraphAsTab: boolean;
 }) => {
-  const defaultTab = props.displayGraphAsTab ? 'graph' : 'data';
-  const [currentTab, setCurrentTab] = useState(defaultTab);
+  const { currentTab, setCurrentTab } = props;
   const currentStep = props.steps.find(
     (step) => step.step_start_log.sequence_id === props.currentSequenceID
   );

--- a/telemetry/ui/src/utils.tsx
+++ b/telemetry/ui/src/utils.tsx
@@ -1,4 +1,4 @@
-import { Step } from './api';
+import { AttributeModel, Step } from './api';
 
 export type Status = 'success' | 'failure' | 'running';
 /*
@@ -13,4 +13,8 @@ export const getActionStatus = (action: Step) => {
     return 'failure';
   }
   return 'success';
+};
+
+export const getUniqueAttributeID = (attribute: AttributeModel) => {
+  return `${attribute.action_sequence_id}-${attribute.span_id}`;
 };


### PR DESCRIPTION
Logs attributes using the __tracer. Decisions:
1. We can log both with the tracer factory and the tracer. You have to log the right one to get it at the right scope
2. Keys are unique on spanID/action (not enforced yet)
3. Saved to log file as a new entry
4. Visualized in the UI
5. No async implemented yet
6. Uses standard serde (could probably document this better)


See this:
```python
from burr.visibility import TracingFactory
from burr.core import action

@action(reads=['prompt'], writes=['response'])
def my_action(state: State, __tracer: TracingFactory) -> State:
    __tracer.log_attribute(prompt_length=len(state["prompt"]), prompt=state["prompt"])
    with __tracer('create_prompt') as t:
        modified_prompt = _modify_prompt(state["prompt"])
        t.log_attribute(modified_prompt=modified_prompt)
        with __tracer('check_prompt_safety') as t:
            if is_unsafe:=_is_unsafe(modified_prompt):
                modified_prompt = _fix(modified_prompt)
            t.log_attribute(fixed_prompt=modified_prompt, is_unsafe=is_unsafe)
    with __tracer('call_llm', dependencies=['create_prompt']):
        response = _query(prompt=modified_prompt)
        t.log_attribute(response=response.message, tokens=response.tokens)
    return state.update({'response': response.message})
```

Need to get working on s3

## Changes
See above/commit messages.

## How I tested this

Locally + unit tests

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
