### PR TITLE
feat: improve default viz

### DIFF
--- a/burr/core/graph.py
+++ b/burr/core/graph.py
@@ -140,6 +140,8 @@ class Graph:
             ),
             node_attr=dict(
                 fontname="Helvetica",
+                margin="0.15",
+                fillcolor="#b4d8e4",
             ),
         )
         for g_key, g_value in engine_kwargs.items():
@@ -154,7 +156,7 @@ class Graph:
                 if not include_state
                 else f"{action.name}({', '.join(action.reads)}): {', '.join(action.writes)}"
             )
-            digraph.node(action.name, label=label, shape="box", style="rounded")
+            digraph.node(action.name, label=label, shape="box", style="rounded,filled")
             required_inputs, optional_inputs = action.optional_and_required_inputs
             for input_ in required_inputs | optional_inputs:
                 if input_.startswith("__"):

--- a/tests/core/test_graphviz_display.py
+++ b/tests/core/test_graphviz_display.py
@@ -1,0 +1,53 @@
+import pathlib
+
+import pytest
+
+from burr.core.graph import GraphBuilder
+
+from tests.core.test_graph import PassedInAction
+
+
+@pytest.fixture
+def base_counter_action():
+    yield PassedInAction(
+        reads=["count"],
+        writes=["count"],
+        fn=lambda state: {"count": state.get("count", 0) + 1},
+        update_fn=lambda result, state: state.update(**result),
+        inputs=[],
+    )
+
+
+@pytest.fixture
+def graph(base_counter_action):
+    yield (
+        GraphBuilder()
+        .with_actions(counter=base_counter_action)
+        .with_transitions(("counter", "counter"))
+        .build()
+    )
+
+
+@pytest.mark.parametrize(
+    "filename, keep_dot", [("app", False), ("app.png", False), ("app", True), ("app.png", True)]
+)
+def test_visualize_dot_output(graph, tmp_path: pathlib.Path, filename: str, keep_dot: bool):
+    """Handle file generation with `graph.Digraph` `.render()` and `.pipe()`"""
+    output_file_path = f"{tmp_path}/{filename}"
+
+    graph.visualize(
+        output_file_path=output_file_path,
+        keep_dot=keep_dot,
+    )
+
+    # assert pathlib.Path(tmp_path, "app.png").exists()
+    assert pathlib.Path(tmp_path, "app").exists() == keep_dot
+
+
+def test_visualize_no_dot_output(graph, tmp_path: pathlib.Path):
+    """Check that no dot file is generated when output_file_path=None"""
+    dot_file_path = tmp_path / "dag"
+
+    graph.visualize(output_file_path=None)
+
+    assert not dot_file_path.exists()


### PR DESCRIPTION
Small quality improvements to the graphviz render of the application graph.

This takes inspiration from [create_graphviz_graph()](https://github.com/DAGWorks-Inc/hamilton/blob/1378c240da2612e0fa11c75bdce5d1b8371dc491/hamilton/graph.py#L199) and [display()](https://github.com/DAGWorks-Inc/hamilton/blob/1378c240da2612e0fa11c75bdce5d1b8371dc491/hamilton/graph.py#L840]
from Hamilton

## Changes
- Helvetica is the default font
- graph nodes are now blue (easier to distinguish from inputs)
- input nodes have a square shape (takes less space then ellipses for layout)
- automatically infer file format from `output_file_path`

## How I tested this
- added tests for the output file name and dot file
