### PR TITLE
@trace decorator for non-burr functions

### DIFF
--- a/burr/lifecycle/base.py
+++ b/burr/lifecycle/base.py
@@ -361,6 +361,7 @@ class PostApplicationExecuteCallHookAsync(abc.ABC):
 # strictly for typing -- this conflicts a bit with the lifecycle decorator above, but its fine for now
 # This makes IDE completion/type-hinting easier
 LifecycleAdapter = Union[
+    DoLogAttributeHook,
     PreRunStepHook,
     PreRunStepHookAsync,
     PostRunStepHook,

--- a/burr/lifecycle/internal.py
+++ b/burr/lifecycle/internal.py
@@ -104,6 +104,14 @@ class LifecycleAdapterSet:
         self._adapters = list(adapters)
         self.sync_hooks, self.async_hooks = self._get_lifecycle_hooks()
 
+    def with_new_adapters(self, *adapters: "LifecycleAdapter") -> "LifecycleAdapterSet":
+        """Adds new adapters to the set.
+
+        :param adapters: Adapters to add
+        :return: A new adapter set with the new adapters
+        """
+        return LifecycleAdapterSet(*self.adapters, *adapters)
+
     def _get_lifecycle_hooks(
         self,
     ) -> Tuple[Dict[str, List["LifecycleAdapter"]], Dict[str, List["LifecycleAdapter"]]]:

--- a/burr/visibility/__init__.py
+++ b/burr/visibility/__init__.py
@@ -1,3 +1,3 @@
-from burr.visibility.tracing import ActionSpan, ActionSpanTracer, TracerFactory
+from burr.visibility.tracing import ActionSpan, ActionSpanTracer, TracerFactory, trace
 
-__all__ = ["TracerFactory", "ActionSpan", "ActionSpanTracer"]
+__all__ = ["TracerFactory", "ActionSpan", "ActionSpanTracer", "trace"]

--- a/docs/reference/visibility.rst
+++ b/docs/reference/visibility.rst
@@ -8,11 +8,15 @@ Tracing Inside Actions
 Tooling for gaining visibility inside actions. You will never instantiate these directly,
 they are all injected by the framework. This is purely for reference.
 
-.. autoclass:: burr.visibility.TracerFactory
+.. autoclass:: burr.visibility.tracing.TracerFactory
     :members:
 
-.. autoclass:: burr.visibility.ActionSpanTracer
+.. autoclass:: burr.visibility.tracing.ActionSpanTracer
     :members:
 
-.. autoclass:: burr.visibility.ActionSpan
+
+.. autoclass:: burr.visibility.tracing.ActionSpan
     :members:
+
+.. autoclass:: burr.visibility.tracing.trace
+    :special-members: __init__

--- a/tests/visibility/test_tracing.py
+++ b/tests/visibility/test_tracing.py
@@ -10,11 +10,16 @@ from burr.lifecycle.base import (
     PreStartSpanHookAsync,
 )
 from burr.lifecycle.internal import LifecycleAdapterSet
+from burr.visibility import tracing
 from burr.visibility.tracing import ActionSpan, TracerFactory
 
 # There are a lot of state-specific assertions in this file
 # We try to comment them. We should also probably organize them to be
 # smaller and test specific things, but this is easier to validate for now
+
+
+def is_subset(dict_subset, dict_full):
+    return all(item in dict_full.items() for item in dict_subset.items())
 
 
 def test_action_span_tracer_correct_span_count(request):
@@ -363,25 +368,26 @@ async def test_pre_span_lifecycle_hooks_called_async(request):
     ]
 
 
+class AttributeHook(DoLogAttributeHook):
+    def do_log_attributes(
+        self,
+        *,
+        attributes: Dict[str, Any],
+        action: str,
+        action_sequence_id: int,
+        span: Optional["ActionSpan"],
+        tags: dict,
+        **future_kwargs: Any,
+    ):
+        self.attributes.append(
+            (attributes, action, action_sequence_id, span.uid if span is not None else None)
+        )
+
+    def __init__(self):
+        self.attributes = []
+
+
 async def test_log_attributes_called(request):
-    class AttributeHook(DoLogAttributeHook):
-        def do_log_attributes(
-            self,
-            *,
-            attributes: Dict[str, Any],
-            action: str,
-            action_sequence_id: int,
-            span: Optional["ActionSpan"],
-            tags: dict,
-            **future_kwargs: Any,
-        ):
-            self.artifacts.append(
-                (attributes, action, action_sequence_id, span.uid if span is not None else None)
-            )
-
-        def __init__(self):
-            self.artifacts = []
-
     hook = AttributeHook()
     adapter_set = LifecycleAdapterSet(hook)
     context_var: ContextVar[Optional[ActionSpan]] = ContextVar(request.node.name, default=None)
@@ -438,7 +444,7 @@ async def test_log_attributes_called(request):
             pass
 
     # order of this is exactly as expected -- in order traversal
-    assert hook.artifacts == [
+    assert hook.attributes == [
         ({"key": "root:0"}, "test_action", 0, None),
         ({"key": "0:0"}, "test_action", 0, "0:0"),
         ({"key": "0.0:0"}, "test_action", 0, "0:0.0"),
@@ -453,3 +459,189 @@ async def test_log_attributes_called(request):
         ({"key": "1.0.1:0"}, "test_action", 0, "0:1.0.1"),
         ({"key": "1.0.1:1"}, "test_action", 0, "0:1.0.1"),
     ]
+
+
+def test_trace_decorator_single_fn(request):
+    # Mock an action span context var
+    # This is set by the tracer factory, which uses the default in tracing
+    # This is so we know the current (context aware) span
+    context_var: ContextVar[Optional[ActionSpan]] = ContextVar(
+        request.node.name,
+        default=None,
+    )
+    # Mock a tracer factory context var
+    # This is set usually by the application so the decorator knows what to get
+    tracer_factory_context_var = ContextVar[TracerFactory](
+        request.node.name + "_tracer", default=None
+    )
+    # Create a hook so we can wire it through and ensure the right thing gets called
+    hook = AttributeHook()
+    adapter_set = LifecycleAdapterSet(hook)
+
+    # Create and set the var to a tracer factory that is context-aware
+    tracer_factory = TracerFactory(
+        action="test_action",
+        sequence_id=0,
+        lifecycle_adapters=adapter_set,
+        _context_var=context_var,
+        app_id="test_app_id",
+        partition_key=None,
+    )
+    tracer_factory_context_var.set(tracer_factory)
+    # Nothing set now
+    assert context_var.get() is None  # nothing to start
+    assert tracer_factory.top_level_span_count == 0  # and thus no top-level spans
+    # Instantiate a decorator that will set the action span when it enters, and unset once it leaves
+    decorator = tracing.trace(
+        _context_var=tracer_factory_context_var, input_filterlist=["filtered_out"]
+    )
+
+    # Then the function can assert things for us
+    # We ensure it gets called by checking the output
+    def foo(a: int, b: int, filtered_out: str = "not_present") -> int:
+        action_span_context = context_var.get()
+        assert action_span_context is not None  # context is now set as we entered the manager
+        assert action_span_context.name == foo.__name__  # span name should match the function name
+        assert action_span_context.child_count == 0  # no children (now)
+        return a + b
+
+    decorated_foo = decorator(foo)
+    result = decorated_foo(1, 2)
+    assert result == 3
+    assert is_subset({"a": 1, "b": 2}, hook.attributes[0][0])
+    assert is_subset({"return": 3}, hook.attributes[2][0])
+
+
+async def test_trace_decorator_single_fn_async(request):
+    context_var: ContextVar[Optional[ActionSpan]] = ContextVar(
+        request.node.name,
+        default=None,
+    )
+    tracer_factory_context_var = ContextVar[TracerFactory](
+        request.node.name + "_tracer", default=None
+    )
+    hook = AttributeHook()
+    adapter_set = LifecycleAdapterSet(hook)
+
+    tracer_factory = TracerFactory(
+        action="test_action",
+        sequence_id=0,
+        lifecycle_adapters=adapter_set,
+        _context_var=context_var,
+        app_id="test_app_id",
+        partition_key=None,
+    )
+    tracer_factory_context_var.set(tracer_factory)
+    assert context_var.get() is None  # nothing to start
+    assert tracer_factory.top_level_span_count == 0  # and thus no top-level spans
+    decorator = tracing.trace(
+        _context_var=tracer_factory_context_var, input_filterlist=["filtered_out"]
+    )
+
+    async def foo(a: int, b: int, filtered_out: str = "not_present") -> int:
+        action_span_context = context_var.get()
+        assert action_span_context is not None  # context is now set as we entered the manager
+        assert action_span_context.name == foo.__name__  # span name should match the function name
+        assert action_span_context.child_count == 0  # no children (now)
+        await asyncio.sleep(0.001)
+        return a + b
+
+    decorated_foo = decorator(foo)
+    result = await decorated_foo(1, 2)
+    assert result == 3
+    assert is_subset({"a": 1, "b": 2}, hook.attributes[0][0])
+    assert is_subset({"return": 3}, hook.attributes[2][0])
+
+
+def test_trace_decorator_recursive(request):
+    context_var: ContextVar[Optional[ActionSpan]] = ContextVar(
+        request.node.name,
+        default=None,
+    )
+    hook = AttributeHook()
+    tracer_factory_context_var = ContextVar[TracerFactory](
+        request.node.name + "_tracer", default=None
+    )
+    tracer_factory = TracerFactory(
+        action="test_action",
+        sequence_id=0,
+        lifecycle_adapters=LifecycleAdapterSet(hook),
+        _context_var=context_var,
+        app_id="test_app_id",
+        partition_key=None,
+    )
+    tracer_factory_context_var.set(tracer_factory)
+    assert context_var.get() is None  # nothing to start
+    assert tracer_factory.top_level_span_count == 0  # and thus no top-level spans
+    decorator = tracing.trace(_context_var=tracer_factory_context_var)
+
+    @decorator
+    def foo(a: int, b: int) -> int:
+        action_span_context = context_var.get()
+        assert action_span_context is not None  # context is now set as we entered the manager
+        assert action_span_context.name == foo.__name__  # span name should match the function name
+        return bar(a + 1, a + b) + a + b
+
+    @decorator
+    def bar(a: int, b: int) -> int:
+        action_span_context = context_var.get()
+        assert action_span_context is not None  # context is now set as we entered the manager
+        assert action_span_context.name == bar.__name__  # span name should match the function name
+        assert action_span_context.child_count == 0  # no children (now)
+        assert action_span_context.parent.name == foo.__name__  # parent should be foo
+        return a * b
+
+    result = foo(1, 2)
+    assert result == 9
+    assert is_subset({"a": 1, "b": 2}, hook.attributes[0][0])
+    assert is_subset({"a": 2, "b": 3}, hook.attributes[2][0])
+    assert is_subset({"return": 6}, hook.attributes[4][0])
+    assert is_subset({"return": 9}, hook.attributes[5][0])
+
+
+async def test_trace_decorator_recursive_async(request):
+    context_var: ContextVar[Optional[ActionSpan]] = ContextVar(
+        request.node.name,
+        default=None,
+    )
+    hook = AttributeHook()
+    tracer_factory_context_var = ContextVar[TracerFactory](
+        request.node.name + "_tracer", default=None
+    )
+    tracer_factory = TracerFactory(
+        action="test_action",
+        sequence_id=0,
+        lifecycle_adapters=LifecycleAdapterSet(hook),
+        _context_var=context_var,
+        app_id="test_app_id",
+        partition_key=None,
+    )
+    tracer_factory_context_var.set(tracer_factory)
+    assert context_var.get() is None  # nothing to start
+    assert tracer_factory.top_level_span_count == 0  # and thus no top-level spans
+    decorator = tracing.trace(_context_var=tracer_factory_context_var)
+
+    @decorator
+    async def foo(a: int, b: int) -> int:
+        action_span_context = context_var.get()
+        assert action_span_context is not None  # context is now set as we entered the manager
+        assert action_span_context.name == foo.__name__  # span name should match the function name
+        await asyncio.sleep(0.001)
+        return await bar(a + 1, a + b) + a + b
+
+    @decorator
+    async def bar(a: int, b: int) -> int:
+        action_span_context = context_var.get()
+        assert action_span_context is not None  # context is now set as we entered the manager
+        assert action_span_context.name == bar.__name__  # span name should match the function name
+        assert action_span_context.child_count == 0  # no children (now)
+        assert action_span_context.parent.name == foo.__name__  # parent should be foo
+        await asyncio.sleep(0.001)
+        return a * b
+
+    result = await foo(1, 2)
+    assert result == 9
+    assert is_subset({"a": 1, "b": 2}, hook.attributes[0][0])
+    assert is_subset({"a": 2, "b": 3}, hook.attributes[2][0])
+    assert is_subset({"return": 6}, hook.attributes[4][0])
+    assert is_subset({"return": 9}, hook.attributes[5][0])


### PR DESCRIPTION
Trace decorator for non-burr functions

## Changes

Adds `@trace` decorator to API

## How I tested this

Tests + manual

## Notes

Two things we'll want to fix:
- [ ] We instantiate the tracerfactory object every step. Low overhead (just a dataclass), but might be worth optimizing away anyway.
- [ ] We don't currently pin errors to spans, we'll want to

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
