### PR TITLE
fix: CLI build command

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -94,6 +94,8 @@ def cli():
 
 
 def _build_ui():
+    cmd = "npm install"
+    _command(cmd, capture_output=False)
     cmd = "npm run build --prefix telemetry/ui"
     _command(cmd, capture_output=False)
     # create a symlink so we can get packages inside it...


### PR DESCRIPTION
Before, using the `burr-admin-build-ui` command
defined in `pyproject.toml` would fail. This relies on `burr.cli.__main__:build_ui()`.

This function uses `npm` via subprocesses to
build the JS frontend. The underlying `npm run build` would fail with `sh: react-scripts: command not found`. This is because the `node_modules` dependencies were missing.

related: https://stackoverflow.com/questions/40546231/sh-react-scripts-command-not-found-after-running-npm-start

To fix the issue, make sur to call `npm install`
before `npm run build`. This will install
dependencies the first time and should be a no-op
on subsequent runs

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
