### PR TITLE
fixing typos in documentation

### DIFF
--- a/docs/concepts/planned-capabilities.rst
+++ b/docs/concepts/planned-capabilities.rst
@@ -49,7 +49,7 @@ if an exception is expected, the program will stop early. We will be adding the 
 on exceptions, which will allow you to transition to an error-handling (or retry) action that does not
 need the full outputs of the prior action.
 
-Here is what it would look liek in the current API:
+Here is what it would look like in the current API:
 
 .. code-block:: python
 

--- a/docs/concepts/state-machine.rst
+++ b/docs/concepts/state-machine.rst
@@ -146,7 +146,7 @@ Graph API
 ---------
 
 The application exposes a graph API, allowing you to specify it as a graph separate from application concerns.
-While you likely won't use this in your first few applications, it will become useful when you want ito run it
+While you likely won't use this in your first few applications, it will become useful when you want to run it
 in a web-server (create a graph once, application many times), import the graph from another context, or run it in multiple contexts.
 
 


### PR DESCRIPTION
[Fix typos in project documentation]

## Changes
- Corrected various typos throughout the project documentation
- Fixed typos in planned-capabilities.rst 
- Fixed typos in state-machine.rst 

## How I tested this
- Reviewed all changed files for accuracy
- re-ran the *python -m pytest tests/* command

## Notes
This pull request focuses solely on improving the readability and professionalism of our documentation by fixing typographical errors. No functional changes were made to the codebase.



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typos in `planned-capabilities.rst` and `state-machine.rst` documentation files.
> 
>   - **Documentation**:
>     - Fixed typos in `planned-capabilities.rst` and `state-machine.rst` to improve readability and professionalism.
>   - **Testing**:
>     - Reviewed changes for accuracy.
>     - Re-ran `python -m pytest tests/` to ensure no functional changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 2519759fb7c29b4d5680415f50f12fae3de5b13c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->