### PR TITLE
Uses the keep_files flag to ensure that the main merge does not clobber the previews

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,14 +39,6 @@ jobs:
           number: ${{ github.event.number }}
           id: deploy-preview
           message: "Starting deployment of preview ⏳..."
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
-          # force_orphan: true # TODO -- determine whether this is the right approach
       - name: Build PR preview website
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref != 'refs/heads/main'
@@ -54,6 +46,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/
           destination_dir: ${{ env.PR_PATH }} # TODO you need to set this if you're using a custom domain. Otherwise you can remove it.
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          keep_files: true # Add this line to keep existing files in the gh-pages branch
       - name: Update comment
         uses: hasura/comment-progress@v2.2.0
         if: github.ref != 'refs/heads/main'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `keep_files: true` to GitHub Pages deployment in `docs.yml` to preserve existing files during main branch merges.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `keep_files: true` to `Deploy to GitHub Pages` step in `docs.yml` to preserve existing files in `gh-pages` during main branch deployments.
>     - Removes commented-out `force_orphan: true` line from the same step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for be6945b4120d0dc165248ef6fb9f21f5c7911f21. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->