### PR TITLE
Bumps burr version from 0.30.2 to 0.30.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
Version bump
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps `burr` version from `0.30.2` to `0.30.3` in `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bumps `burr` version from `0.30.2` to `0.30.3` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 47462a65e9b6b8e33f964ef6da93cea5c38a4e41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->