### PR TITLE
Fixed import statement for Application Typing

### DIFF
--- a/docs/concepts/state-typing.rst
+++ b/docs/concepts/state-typing.rst
@@ -50,7 +50,7 @@ Then, we can use this model to type our application:
 .. code-block:: python
 
     from burr import ApplicationBuilder
-    from burr.core.typing import PydanticTypingSystem
+    from burr.integrations.pydantic import PydanticTypingSystem
 
     app = (
         ApplicationBuilder()


### PR DESCRIPTION
Updated import statement to working example, found in burr/examples/typed-state/notebook.ipynb

Existing docs example was incorrect and caused errors. 

## Changes
Changed import no longer causes error.

## How I tested this
action, result, state = application.run(halt_after=["..."])

state.data is the proper type and has accessible state properties.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix import statement in `state-typing.rst` to correct `PydanticTypingSystem` path.
> 
>   - **Documentation**:
>     - Fix import statement in `state-typing.rst` from `burr.core.typing` to `burr.integrations.pydantic` for `PydanticTypingSystem`.
>     - Ensures example code in documentation runs without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 8c350e1489451e9b48c3345478dd49dc6bb27c1d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->