### PR TITLE
Fix KeyError in _validate_and_extract_signature_types and Add Tests for Pydantic Actions

### DIFF
--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -113,14 +113,13 @@ def _validate_and_extract_signature_types(
         )
     type_hints = typing.get_type_hints(fn)
 
-    if (state_model := type_hints["state"]) is inspect.Parameter.empty or not issubclass(
-        state_model, pydantic.BaseModel
-    ):
+    state_model = type_hints.get("state")
+    if state_model is None or state_model is inspect.Parameter.empty or not issubclass(state_model, pydantic.BaseModel):
         raise ValueError(
             f"Function fn: {fn.__qualname__} is not a valid pydantic action. "
-            "a type annotation of a type extending: pydantic.BaseModel. Got parameter "
-            "state: {state_model.__qualname__}."
+            "The 'state' parameter must be annotated with a type extending pydantic.BaseModel."
         )
+
     if (ret_hint := type_hints.get("return")) is None or not issubclass(
         ret_hint, pydantic.BaseModel
     ):

--- a/tests/integrations/test_burr_pydantic.py
+++ b/tests/integrations/test_burr_pydantic.py
@@ -154,27 +154,27 @@ def test_model_from_state():
 
 
 def _fn_without_state_arg(foo: OriginalModel) -> OriginalModel:
-    ...
+    return foo;
 
 
 def _fn_with_incorrect_state_arg(state: int) -> OriginalModel:
-    ...
+    return OriginalModel(foo, bar)
 
 
 def _fn_with_incorrect_return_type(state: OriginalModel) -> int:
-    ...
+    return 42
 
 
 def _fn_with_no_return_type(state: OriginalModel):
-    ...
+    pass
 
 
 def _fn_correct_same_itype_otype(state: OriginalModel, input_1: int) -> OriginalModel:
-    ...
+    return state
 
 
 def _fn_correct_diff_itype_otype(state: OriginalModel, input_1: int) -> NestedModel:
-    ...
+    return NestedModel(nested_field1=input_1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PR fixes a `KeyError` issue in `_validate_and_extract_signature_types` when the `"state"` key is missing in type hints. It also has error handling and adds unit tests.

## Changes

- Updated `_validate_and_extract_signature_types` to use `.get()`
- Added tests for error
- Enhanced placeholder functions with valid logic in `test_burr_pydantic.py`.

## How I tested this
Added new tests for both error and success cases. Below are the test details:
```bash
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/divya/Code/open_scr/burr/tests
configfile: pytest.ini
plugins: anyio-4.6.2.post1
collected 30 items                                                                                                                                                                           

test_burr_pydantic.py ................s..s...s.s.s.s                                                                                                                                   [100%]

====================================================================================== warnings summary ======================================================================================
../../../../burr/lib/python3.12/site-packages/_pytest/config/__init__.py:1441
  /home/divya/Code/burr/lib/python3.12/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

integrations/test_burr_pydantic.py::test_subset_model_copy_config
  /home/divya/Code/burr/lib/python3.12/site-packages/pydantic/_internal/_config.py:291: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

integrations/test_burr_pydantic.py::test_pydantic_action_returns_correct_results_same_io_modified_async
integrations/test_burr_pydantic.py::test_pydantic_action_returns_correct_results_different_io_modified_async
integrations/test_burr_pydantic.py::test_streaming_pydantic_action_same_io_async
integrations/test_burr_pydantic.py::test_streaming_pydantic_action_different_io_async
integrations/test_burr_pydantic.py::test_end_to_end_pydantic_async
integrations/test_burr_pydantic.py::test_end_to_end_pydantic_streaming_async
  /home/divya/Code/burr/lib/python3.12/site-packages/_pytest/python.py:148: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= 24 passed, 6 skipped, 8 warnings in 1.92s ==========================================================================
```

## Notes
ensures better debugging and avoids cryptic errors , closed #385 

## Checklist
- [Yes] PR has an informative and human-readable title (this will be pulled into the release notes)
- [Yes] Changes are limited to a single goal (no scope creep)
- [Yes] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [Yes] Any _change_ in functionality is tested
- [No] New functions are documented (with a description, list of inputs, and expected output)
- [No] Placeholder code is flagged / future TODOs are captured in comments
- [No] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `KeyError` in `_validate_and_extract_signature_types` and add tests for Pydantic actions.
> 
>   - **Bug Fix**:
>     - Fix `KeyError` in `_validate_and_extract_signature_types` in `pydantic.py` by using `.get()` for "state" key.
>   - **Tests**:
>     - Add tests in `test_burr_pydantic.py` for `_validate_and_extract_signature_types` to cover missing "state" key and incorrect return types.
>     - Enhance placeholder functions in `test_burr_pydantic.py` with valid logic for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 5a91b6b023bea07ba6a97760dc65484fc07bbde9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->