### PR TITLE
Bumps Burr from 0.31.1 to 0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
Version bump
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps version from 0.31.1 to 0.32.0 in `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bumps version from `0.31.1` to `0.32.0` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for ffd375f98f8546a67f2d94c8a0a102f6222ae91f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->