### PR TITLE
feat: `%burr_ui` magic to launch UI from notebook

### DIFF
--- a/burr/integrations/notebook.py
+++ b/burr/integrations/notebook.py
@@ -1,0 +1,135 @@
+import enum
+import os
+import subprocess
+
+from IPython.core.magic import Magics, line_magic, magics_class
+from IPython.core.shellapp import InteractiveShellApp
+
+
+class NotebookEnvironment(enum.Enum):
+    JUPYTER = enum.auto()
+    COLAB = enum.auto()
+    VSCODE = enum.auto()
+    DATABRICKS = enum.auto()
+    KAGGLE = enum.auto()
+
+
+def identify_notebook_environment(ipython: InteractiveShellApp) -> NotebookEnvironment:
+    if "IPKernelApp" in ipython.config:
+        return NotebookEnvironment.JUPYTER
+
+    if os.environ.get("VSCODE_PID"):
+        return NotebookEnvironment.VSCODE
+
+    try:
+        import google.colab  # noqa: F401
+
+        return NotebookEnvironment.COLAB
+    except ModuleNotFoundError:
+        pass
+
+    try:
+        import dbruntime  # noqa: F401
+
+        return NotebookEnvironment.DATABRICKS
+    except ModuleNotFoundError:
+        pass
+
+    try:
+        import kaggle  # noqa: F401
+
+        return NotebookEnvironment.KAGGLE
+    except ModuleNotFoundError:
+        pass
+
+    raise RuntimeError(
+        f"Unknown notebook environment. Supported environments: {list(NotebookEnvironment)}"
+    )
+
+
+def launch_ui_colab():
+    """Opens a Google Colab port and launches the Burr UI in a subprocess.
+
+    Using a subprocess ensures that the Burr server logs aren't displayed in
+    Colab cell outputs.
+
+    NOTE. This will not work in a Jupyter notebook
+    """
+    from google.colab.output import eval_js
+
+    PORT = 7241
+    burr_ui_url = eval_js(f"google.colab.kernel.proxyPort({PORT})")
+    process = subprocess.Popen(
+        [
+            "python",
+            "-c",
+            f"import uvicorn; from burr.tracking.server.run import app; uvicorn.run(app, host='127.0.0.1', port={PORT})",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return process, burr_ui_url
+
+
+def launch_ui_jupyter():
+    HOST = "127.0.0.1"
+    PORT = 7241
+    process = subprocess.Popen(
+        [
+            "python",
+            "-c",
+            f"import uvicorn; from burr.tracking.server.run import app; uvicorn.run(app, host='{HOST}', port={PORT})",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return process, f"http://{HOST}:{PORT}"
+
+
+def launch_ui(notebook_env: NotebookEnvironment) -> tuple:
+    process, url = None, None
+    if notebook_env == NotebookEnvironment.COLAB:
+        process, url = launch_ui_colab()
+    else:
+        try:
+            process, url = launch_ui_jupyter()
+        except ModuleNotFoundError as e:
+            raise RuntimeError(
+                f"Failed to launch Burr UI for environment {notebook_env}. Please report this issue."
+            ) from e
+
+    return process, url
+
+
+@magics_class
+class NotebookMagics(Magics):
+    def __init__(self, notebook_env: NotebookEnvironment, **kwargs):
+        super().__init__(**kwargs)
+        self.notebook_env = notebook_env
+        self.process = None
+        self.url = None
+
+    @line_magic
+    def burr_ui(self, line):
+        """Opens a Google Colab port and launches the Burr UI in a subprocess.
+
+        Using a subprocess ensures that the Burr server logs aren't displayed in
+        Colab cell outputs.
+
+        NOTE. This will not work in a Jupyter notebook
+        """
+        if self.process is not None:
+            print(f"Burr UI already running at {self.url}")
+            return
+
+        self.process, self.url = launch_ui(self.notebook_env)
+        print(f"Burr UI: {self.url}")
+
+
+def load_ipython_extension(ipython: InteractiveShellApp):
+    """
+    Any module file that define a function named `load_ipython_extension`
+    can be loaded via `%load_ext module.path` or be configured to be
+    autoloaded by IPython at startup time.
+    """
+    ipython.register_magics(NotebookMagics(notebook_env=identify_notebook_environment(ipython)))

--- a/burr/integrations/notebook.py
+++ b/burr/integrations/notebook.py
@@ -28,6 +28,7 @@ def identify_notebook_environment(ipython: InteractiveShellApp) -> NotebookEnvir
     except ModuleNotFoundError:
         pass
 
+    # TODO add Databricks implementation
     try:
         import dbruntime  # noqa: F401
 
@@ -35,6 +36,7 @@ def identify_notebook_environment(ipython: InteractiveShellApp) -> NotebookEnvir
     except ModuleNotFoundError:
         pass
 
+    # TODO add Kaggle implementation
     try:
         import kaggle  # noqa: F401
 
@@ -43,7 +45,7 @@ def identify_notebook_environment(ipython: InteractiveShellApp) -> NotebookEnvir
         pass
 
     raise RuntimeError(
-        f"Unknown notebook environment. Supported environments: {list(NotebookEnvironment)}"
+        f"Unknown notebook environment. Known environments: {list(NotebookEnvironment)}"
     )
 
 
@@ -72,6 +74,10 @@ def launch_ui_colab():
 
 
 def launch_ui_jupyter():
+    """Launch the Burr UI in a subprocess.
+
+    Using a subprocess ensures that the Burr server logs aren't displayed in Colab cell outputs
+    """
     HOST = "127.0.0.1"
     PORT = 7241
     process = subprocess.Popen(
@@ -111,13 +117,7 @@ class NotebookMagics(Magics):
 
     @line_magic
     def burr_ui(self, line):
-        """Opens a Google Colab port and launches the Burr UI in a subprocess.
-
-        Using a subprocess ensures that the Burr server logs aren't displayed in
-        Colab cell outputs.
-
-        NOTE. This will not work in a Jupyter notebook
-        """
+        """Launch the Burr UI from a notebook cell"""
         if self.process is not None:
             print(f"Burr UI already running at {self.url}")
             return

--- a/docs/concepts/tracking.rst
+++ b/docs/concepts/tracking.rst
@@ -92,19 +92,16 @@ run it with the following command:
 This will start a server on port 7241, and open up a browser window with the UI for you to explore.
 
 
-Using Burr in Google Collab
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you run Burr in Google Collab, you can use the following code to expose the Burr UI to your browser:
+Launch Burr UI from a notebook
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can launch the Burr UI from a notebook or Google Colab using the ``%burr_ui`` "IPython magic".
+This will print the URL to access the Burr UI web app.
 
 .. code-block:: python
 
     # in one cell - expose the port:
-    from google.colab import output
-    output.serve_kernel_port_as_window(7241)
+    %load_ext burr.integrations.notebook
+    %burr_ui
 
-.. code-block:: bash
-
-    # in another cell - start burr: (! denotes a command line call)
-    !burr &
-    # now click the localhost:7241 from the prior cell.
-    # It should open up a new tab with the burr UI!
+    "Burr UI: http://127.0.0.1:7241"


### PR DESCRIPTION
This allows to launch Burr UI from a notebook. This is particularly useful in Google Colab environments because it automatically fowards the necessary port.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `%burr_ui` IPython magic to launch Burr UI from notebooks, supporting Google Colab and Jupyter environments.
> 
>   - **New Feature**:
>     - Adds `%burr_ui` IPython magic command in `burr/integrations/notebook.py` to launch Burr UI from notebooks.
>     - Supports Google Colab and Jupyter environments.
>   - **Functions**:
>     - `identify_notebook_environment()` determines the notebook environment.
>     - `launch_ui_colab()` and `launch_ui_jupyter()` handle UI launching for Colab and Jupyter.
>     - `NotebookMagics` class implements the `%burr_ui` magic.
>   - **Documentation**:
>     - Updates `docs/concepts/tracking.rst` to include usage of `%burr_ui` for launching Burr UI from notebooks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for b087e32af1f8c038e15e3554396e6e61ab66ebcf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->