### PR TITLE
Add py.typed to be PEP 561 compliant

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include burr/tracking/server/demo_data *
 recursive-include burr/tracking/server/build *
 recursive-include examples/ *
+global-include *.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,8 @@ include = ["burr", "burr.*"]
 [tool.setuptools.package-data]
 burr = [
   "burr/tracking/server/build/**/*",
-  "burr/tracking/server/demo_data/**/*"
+  "burr/tracking/server/demo_data/**/*",
+  "py.typed",
 ]
 
 


### PR DESCRIPTION
Add `py.typed` to burr for being [PEP 561](https://peps.python.org/pep-0561/) compliant.

So far, after installing burr, and run mypy to type check the code that depends on the burr library, mypy will complain as follows:

```
src/application.py:8: error: Skipping analyzing "burr.core": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/application.py:9: error: Skipping analyzing "burr.core.action": module is installed, but missing library stubs or py.typed marker  [import-untyped
```

That is because the library right now does not provide a `py.typed` file, and mypy cannot find typing infomation of burr as a dependency, despite the implementation of burr has been pretty well-typed.

See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

## Changes

* New file `burr/py.typed`.

## How I tested this

I installed burr from

```
uv add git+https://github.com/shun-liang/burr
```

and after the above errors "Skipping analyzing" from mypy are gone.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `py.typed` to `burr` for PEP 561 compliance, resolving mypy type information errors.
> 
>   - **PEP 561 Compliance**:
>     - Add `py.typed` file to `burr` to make it PEP 561 compliant.
>     - Resolves mypy errors related to missing type information for `burr`.
>   - **Testing**:
>     - Verified by installing `burr` and confirming mypy no longer reports missing type information errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for fee9a0bd3c1fce6fc16323bbea9f279e715b56f6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->