### PR TITLE
notebook integration: `%burr_ui` can show the web app in an `iframe`

### DIFF
--- a/burr/integrations/notebook.py
+++ b/burr/integrations/notebook.py
@@ -120,7 +120,8 @@ class NotebookMagics(Magics):
 
     @magic_arguments()
     @argument(
-        "--height", "-h",
+        "--height",
+        "-h",
         default=400,
         type=int,
         help="Height of the Burr UI iframe specified as a number of pixels",
@@ -128,7 +129,7 @@ class NotebookMagics(Magics):
     @argument(
         "--no-iframe",
         action="store_true",
-        help="Passing this flag prints the URL of the launched Burr UI instead of displaying an iframe."
+        help="Passing this flag prints the URL of the launched Burr UI instead of displaying an iframe.",
     )
     @line_magic
     def burr_ui(self, line):

--- a/burr/integrations/notebook.py
+++ b/burr/integrations/notebook.py
@@ -17,9 +17,6 @@ class NotebookEnvironment(enum.Enum):
 
 
 def identify_notebook_environment(ipython: InteractiveShellApp) -> NotebookEnvironment:
-    if "IPKernelApp" in ipython.config:
-        return NotebookEnvironment.JUPYTER
-
     if os.environ.get("VSCODE_PID"):
         return NotebookEnvironment.VSCODE
 
@@ -45,6 +42,10 @@ def identify_notebook_environment(ipython: InteractiveShellApp) -> NotebookEnvir
         return NotebookEnvironment.KAGGLE
     except ModuleNotFoundError:
         pass
+
+    # this is the base case. IPKernelApp should always be available
+    if "IPKernelApp" in ipython.config:
+        return NotebookEnvironment.JUPYTER
 
     raise RuntimeError(
         f"Unknown notebook environment. Known environments: {list(NotebookEnvironment)}"


### PR DESCRIPTION
Adds the arguments `--no-iframe` (default is enabling iframe) and `--height`.

Notes:
- it doesn't seem to make sense to resize to less than `100%` so there's not `width` arg
- calling `%burr_ui` multiple times will check if the subprocess exited before retrying. If there's a bug in launching the UI, the user may repeatedly hit "launch"
- there's no way to kill the subprocess except restarting the notebook kernel. However,  we guard against launching more than 1 subprocess. 