### PR TITLE
Fixes bug in which inputs were not working for asynchronous applications

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -874,7 +874,7 @@ class Application(Generic[ApplicationStateType]):
             raise ValueError(
                 BASE_ERROR_MESSAGE
                 + f"Inputs starting with a double underscore ({starting_with_double_underscore}) "
-                f"are reserved for internal use/injected inputs."
+                f"are reserved for internal use/injected inputs. "
                 "Please do not directly pass keys starting with a double underscore."
             )
         inputs = inputs.copy()
@@ -945,13 +945,12 @@ class Application(Generic[ApplicationStateType]):
                 return None
             if inputs is None:
                 inputs = {}
-            action_inputs = self._process_inputs(inputs, next_action)
             if _run_hooks:
                 await self._adapter_set.call_all_lifecycle_hooks_sync_and_async(
                     "pre_run_step",
                     action=next_action,
                     state=self._state,
-                    inputs=action_inputs,
+                    inputs=inputs,
                     sequence_id=self.sequence_id,
                     app_id=self._uid,
                     partition_key=self._partition_key,
@@ -966,9 +965,12 @@ class Application(Generic[ApplicationStateType]):
                     # TODO -- add an option/configuration to launch a thread (yikes, not super safe, but for a pure function
                     # which this is supposed to be its OK).
                     # this delegates hooks to the synchronous version, so we'll call all of them as well
+                    # In this case we allow the self._step to do input processing
                     return self._step(
-                        inputs=action_inputs, _run_hooks=False
+                        inputs=inputs, _run_hooks=False
                     )  # Skip hooks as we already ran all of them/will run all of them in this function's finally
+                # In this case we want to process inputs because we run the function directly
+                action_inputs = self._process_inputs(inputs, next_action)
                 if next_action.single_step:
                     result, new_state = await _arun_single_step_action(
                         next_action, self._state, inputs=action_inputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
See #439. We were filing with required inputs twice -- this ensures it only happens once. We were calling _step from _astep, both of which did this.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes double input processing in asynchronous applications by adjusting input handling in `Application._astep()` and adds tests for context and input handling.
> 
>   - **Behavior**:
>     - Fixes double processing of inputs in `Application._astep()` in `application.py` by ensuring inputs are processed only once.
>     - Adjusts input handling logic to prevent redundant processing when calling `_step` from `_astep`.
>   - **Tests**:
>     - Adds `test_app_astep_context()` and `test_app_step_context()` in `test_application.py` to verify context passing in async and sync steps.
>     - Adds `test_app_astep_with_inputs()` to ensure inputs are correctly handled in async steps.
>   - **Misc**:
>     - Minor string formatting fix in `application.py`.
>     - Bumps version in `pyproject.toml` from `0.33.2` to `0.33.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 7124276c01005de20967e6a929a36c07f0f42537. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->