### PR TITLE
Adds note on ApplicationContext and how to use it

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -492,6 +492,20 @@ class ApplicationContext(AbstractContextManager):
     Often used for recursive tracking.
 
     Note this is also a context manager (allowing you to pass context to sub-applications).
+
+    To access this object in a running application, you can use the `__context` variable in the
+    action signature:
+
+    .. code-block:: python
+
+        from burr.core import action, State, ApplicationContext
+
+        @action(reads=[...], writes=[...])
+        def my_action(state: State, __context: ApplicationContext) -> State:
+            app_id = __context.app_id
+            partition_key = __context.partition_key
+            ...
+
     """
 
     app_id: str

--- a/docs/concepts/state-persistence.rst
+++ b/docs/concepts/state-persistence.rst
@@ -50,7 +50,7 @@ injected into your Burr Actions. This is done by adding ``__context`` to the act
 
     from burr.core import action, State, ApplicationContext
 
-    @action
+    @action(reads=[...], writes=[...])
     def my_action(state: State, __context: ApplicationContext) -> State:
         app_id = __context.app_id
         partition_key = __context.partition_key

--- a/docs/concepts/state-persistence.rst
+++ b/docs/concepts/state-persistence.rst
@@ -35,13 +35,27 @@ State Keys
 ----------
 Burr `applications` are, by default, keyed on two entities:
 
-1. ``app_uid`` - A unique identifier for the application. This is used to identify the application in the persistence layer.
+1. ``app_id`` - A unique identifier for the application. This is used to identify the application in the persistence layer.
 2. ``partition_key`` - An identifier for grouping (partitioning) applications
 
-In the case of a chatbot, the ``app_uid`` could be a uuid, and the ``partition_key`` could be the user's name.
-Note that ``partition_key`` can be `None` if this is not relevant. A UUID is always generated for the ``app_uid`` if not provided.
+In the case of a chatbot, the ``app_id`` could be a uuid, and the ``partition_key`` could be the user's ID or email, etc.
+Note that ``partition_key`` can be `None` if this is not relevant. A UUID is always generated for the ``app_id`` if not provided.
 
 You set these values using the :py:meth:`with_identifiers() <burr.core.application.ApplicationBuilder.with_identifiers>` method.
+
+Note: to access ``app_id`` and ``partition_key`` in your running application, you can have the :py:class:`ApplicationContext <burr.core.application.ApplicationContext>`
+injected into your Burr Actions. This is done by adding ``__context`` to the action signature:
+
+.. code-block:: python
+
+    from burr.core import action, State, ApplicationContext
+
+    @action
+    def my_action(state: State, __context: ApplicationContext) -> State:
+        app_id = __context.app_id
+        partition_key = __context.partition_key
+        ...
+
 
 Initializing state
 ------------------


### PR DESCRIPTION
So that people know how to access the current app_id, partition_key, or sequence_id...

## Changes
 - docs

## How I tested this
 - via build

## Notes
 - related to https://github.com/DAGWorks-Inc/burr/discussions/445

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation on accessing `ApplicationContext` in Burr applications via `__context` in action signatures.
> 
>   - **Documentation**:
>     - Adds a note in `ApplicationContext` docstring in `application.py` on accessing `app_id`, `partition_key`, and `sequence_id` using `__context` in action signatures.
>     - Updates `state-persistence.rst` to include instructions on injecting `ApplicationContext` into Burr Actions for accessing `app_id` and `partition_key`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for e2b8c7bfd7e4f0e2c9cd4a71caee1787748dacff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->