### PR TITLE
Adds docs for update() function to Reducer

### DIFF
--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -124,6 +124,19 @@ class Reducer(abc.ABC):
 
     @abc.abstractmethod
     def update(self, result: dict, state: State) -> State:
+        """Performs a state update given a result and the current state.
+        Returns a new, modified :py:class:`State <burr.core.state.State>`
+        (recall state is immutable -- simply changing the state in place will not work).
+
+        In the context of Burr, this is only applied in the two-step actions, where
+        the :py:meth:`run <burr.core.action.Function.run>` and update() functions are separate. The
+        function-based APIs for Burr use the SingleStepAction class, which performs them both at once.
+        This is not (yet) exposed as an interface for users to extend.
+
+        :param result: Result of a function executing on the state
+        :param state: State to update
+        :return: A new, modified state.
+        """
         pass
 
 


### PR DESCRIPTION
Requested by @gamarin2!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add docstring to `update()` method in `Reducer` class in `burr/core/action.py` to explain state update process and parameters.
> 
>   - **Docs**:
>     - Add docstring to `update()` method in `Reducer` class in `burr/core/action.py`.
>     - Explains state update process, immutability, and two-step action context.
>     - Describes parameters `result` and `state`, and return value `State`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for d7a5822c746f2f44a238e24e44793ff2940af40e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->