### PR TITLE
Bumps Burr version from 0.34.0 to 0.34.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
version bump
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps `burr` version from `0.34.0` to `0.34.1` in `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bumps `burr` version from `0.34.0` to `0.34.1` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 0b82fa1d5d96fea4cea683cb1956159480f51595. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->