### PR TITLE
Default state for map actions + other minor testing-related fixes

### DIFF
--- a/burr/core/parallelism.py
+++ b/burr/core/parallelism.py
@@ -628,15 +628,17 @@ class MapActions(MapActionsAndStates, abc.ABC):
         :return: Generator of actions to run
         """
 
-    @abc.abstractmethod
     def state(self, state: State, inputs: Dict[str, Any]):
-        """Gives the state for each of the actions
+        """Gives the state for each of the actions.
+        By default, this will give out the current state. That said,
+        you may want to adjust this -- E.G. to translate state into
+        a format the sub-actions would expect.
 
         :param state: State at the time of running the action
         :param inputs: Runtime inputs to the action
         :return: State for the action
         """
-        pass
+        return state
 
     def states(
         self, state: State, context: ApplicationContext, inputs: Dict[str, Any]

--- a/burr/tracking/server/schema.py
+++ b/burr/tracking/server/schema.py
@@ -93,30 +93,30 @@ class Step(pydantic.BaseModel):
             json_line = safe_json_load(line)
             # TODO -- make these into constants
             if json_line["type"] == "begin_entry":
-                begin_step = BeginEntryModel.parse_obj(json_line)
+                begin_step = BeginEntryModel.model_validate(json_line)
                 steps_by_sequence_id[begin_step.sequence_id].step_start_log = begin_step
             elif json_line["type"] == "end_entry":
-                step_end_log = EndEntryModel.parse_obj(json_line)
+                step_end_log = EndEntryModel.model_validate(json_line)
                 steps_by_sequence_id[step_end_log.sequence_id].step_end_log = step_end_log
             elif json_line["type"] == "begin_span":
-                span = BeginSpanModel.parse_obj(json_line)
+                span = BeginSpanModel.model_validate(json_line)
                 spans_by_id[span.span_id] = PartialSpan(
                     begin_entry=span,
                     end_entry=None,
                 )
             elif json_line["type"] == "end_span":
-                end_span = EndSpanModel.parse_obj(json_line)
+                end_span = EndSpanModel.model_validate(json_line)
                 span = spans_by_id[end_span.span_id]
                 span.end_entry = end_span
             elif json_line["type"] == "attribute":
-                attribute = AttributeModel.parse_obj(json_line)
+                attribute = AttributeModel.model_validate(json_line)
                 attributes_by_step[attribute.action_sequence_id].append(attribute)
             elif json_line["type"] in ["begin_stream", "first_item_stream", "end_stream"]:
                 streaming_event = {
                     "begin_stream": InitializeStreamModel,
                     "first_item_stream": FirstItemStreamModel,
                     "end_stream": EndStreamModel,
-                }[json_line["type"]].parse_obj(json_line)
+                }[json_line["type"]].model_validate(json_line)
                 steps_by_sequence_id[streaming_event.sequence_id].streaming_events.append(
                     streaming_event
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ documentation = [
 ]
 
 tracking-client = [
-  "pydantic"
+  "pydantic>1"
 ]
 
 tracking-client-s3 = [

--- a/tests/core/test_application.py
+++ b/tests/core/test_application.py
@@ -3333,7 +3333,7 @@ def test_with_state_persister_is_initialized_not_implemented():
     builder.with_state_persister(persister)
 
 
-class TestActionWithoutContext(Action):
+class ActionWithoutContext(Action):
     def run(self, other_param, foo):
         pass
 
@@ -3352,7 +3352,7 @@ class TestActionWithoutContext(Action):
         return ["other_param", "foo"]
 
 
-class TestActionWithContext(TestActionWithoutContext):
+class ActionWithContext(ActionWithoutContext):
     def run(self, __context, other_param, foo):
         pass
 
@@ -3360,7 +3360,7 @@ class TestActionWithContext(TestActionWithoutContext):
         return ["other_param", "foo", "__context"]
 
 
-class TestActionWithKwargs(TestActionWithoutContext):
+class ActionWithKwargs(ActionWithoutContext):
     def run(self, other_param, foo, **kwargs):
         pass
 
@@ -3368,7 +3368,7 @@ class TestActionWithKwargs(TestActionWithoutContext):
         return ["other_param", "foo", "__context"]
 
 
-class TestActionWithContextTracer(TestActionWithoutContext):
+class ActionWithContextTracer(ActionWithoutContext):
     def run(self, __context, other_param, foo, __tracer):
         pass
 
@@ -3377,7 +3377,7 @@ class TestActionWithContextTracer(TestActionWithoutContext):
 
 
 def test_remap_context_variable_with_mangled_context_kwargs():
-    _action = TestActionWithKwargs()
+    _action = ActionWithKwargs()
 
     inputs = {"__context": "context_value", "other_key": "other_value", "foo": "foo_value"}
     expected = {"__context": "context_value", "other_key": "other_value", "foo": "foo_value"}
@@ -3385,11 +3385,11 @@ def test_remap_context_variable_with_mangled_context_kwargs():
 
 
 def test_remap_context_variable_with_mangled_context():
-    _action = TestActionWithContext()
+    _action = ActionWithContext()
 
     inputs = {"__context": "context_value", "other_key": "other_value", "foo": "foo_value"}
     expected = {
-        f"_{TestActionWithContext.__name__}__context": "context_value",
+        f"_{ActionWithContext.__name__}__context": "context_value",
         "other_key": "other_value",
         "foo": "foo_value",
     }
@@ -3397,7 +3397,7 @@ def test_remap_context_variable_with_mangled_context():
 
 
 def test_remap_context_variable_with_mangled_contexttracer():
-    _action = TestActionWithContextTracer()
+    _action = ActionWithContextTracer()
 
     inputs = {
         "__context": "context_value",
@@ -3406,16 +3406,16 @@ def test_remap_context_variable_with_mangled_contexttracer():
         "foo": "foo_value",
     }
     expected = {
-        f"_{TestActionWithContextTracer.__name__}__context": "context_value",
+        f"_{ActionWithContextTracer.__name__}__context": "context_value",
         "other_key": "other_value",
         "foo": "foo_value",
-        f"_{TestActionWithContextTracer.__name__}__tracer": "tracer_value",
+        f"_{ActionWithContextTracer.__name__}__tracer": "tracer_value",
     }
     assert _remap_dunder_parameters(_action.run, inputs, ["__context", "__tracer"]) == expected
 
 
 def test_remap_context_variable_without_mangled_context():
-    _action = TestActionWithoutContext()
+    _action = ActionWithoutContext()
     inputs = {"__context": "context_value", "other_key": "other_value", "foo": "foo_value"}
     expected = {"__context": "context_value", "other_key": "other_value", "foo": "foo_value"}
     assert _remap_dunder_parameters(_action.run, inputs, ["__context", "__tracer"]) == expected

--- a/tests/core/test_parallelism.py
+++ b/tests/core/test_parallelism.py
@@ -370,6 +370,28 @@ def _group_events_by_app_id(
     return grouped_events
 
 
+def test_map_actions_default_state():
+    class MapActionsAllApproaches(MapActions):
+        def actions(
+            self, state: State, inputs: Dict[str, Any], context: ApplicationContext
+        ) -> Generator[Union[Action, Callable, RunnableGraph], None, None]:
+            ...
+
+        def reduce(self, state: State, states: Generator[State, None, None]) -> State:
+            ...
+
+        @property
+        def writes(self) -> list[str]:
+            return []
+
+        @property
+        def reads(self) -> list[str]:
+            return []
+
+    state_to_test = State({"foo": "bar", "baz": "qux"})
+    assert MapActionsAllApproaches().state(state_to_test, {}).get_all() == state_to_test.get_all()
+
+
 def test_e2e_map_actions_sync_subgraph():
     """Tests map actions over multiple action types (runnable graph, function, action class...)"""
 

--- a/tests/integrations/test_burr_pydantic.py
+++ b/tests/integrations/test_burr_pydantic.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator, Generator, List, Optional, Tuple
 
 import pydantic
 import pytest
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from pydantic.fields import FieldInfo
 
 from burr.core import expr
@@ -110,8 +110,7 @@ def test_subset_model_copy_config():
         foo: int
         arbitrary: Arbitrary
 
-        class Config:
-            arbitrary_types_allowed = True
+        model_config = ConfigDict(arbitrary_types_allowed=True)
 
     SubsetModel = subset_model(MyModelWithConfig, ["foo", "bar"], [], "Subset")
     assert SubsetModel.__name__ == "MyModelWithConfigSubset"


### PR DESCRIPTION
## Changes

Default state for `MapActions` is now the state that was provided. Lowers the amount needed for a common use-case.

Also did a bit of improvements on the testing side as well -- removed warnings from test suite!
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default state for `MapActions` and improve test clarity by renaming classes and adding tests.
> 
>   - **Behavior**:
>     - Default state for `MapActions` now uses the provided state, reducing setup for common use-cases in `parallelism.py`.
>   - **Testing**:
>     - Added `test_map_actions_default_state()` in `test_parallelism.py` to verify default state behavior.
>     - Renamed test classes in `test_application.py` for clarity: `TestActionWithoutContext` to `ActionWithoutContext`, `TestActionWithContext` to `ActionWIthContext`, `TestActionWithKwargs` to `ActionWithKwargs`, and `TestActionWithContextTracer` to `ActionWithContextTracer`.
>   - **Misc**:
>     - Replaced `parse_obj` with `model_validate` in `schema.py` for `BeginEntryModel`, `EndEntryModel`, `BeginSpanModel`, `EndSpanModel`, `AttributeModel`, and streaming events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 10705c426557ccbea1186bc39375556425dacf02. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->