### PR TITLE
Refactors Redis Persister

### DIFF
--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -48,8 +48,7 @@ Currently we support the following, although we highly recommend you contribute 
 
    .. automethod:: __init__
 
-
-.. autoclass:: burr.integrations.persisters.b_redis.RedisPersister
+.. autoclass:: burr.integrations.persisters.b_redis.RedisBasePersister
    :members:
 
    .. automethod:: __init__

--- a/tests/integrations/persisters/test_b_redis.py
+++ b/tests/integrations/persisters/test_b_redis.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from burr.core import state
-from burr.integrations.persisters.b_redis import RedisPersister
+from burr.integrations.persisters.b_redis import RedisBasePersister, RedisPersister
 
 if not os.environ.get("BURR_CI_INTEGRATION_TESTS") == "true":
     pytest.skip("Skipping integration tests", allow_module_level=True)
@@ -11,14 +11,14 @@ if not os.environ.get("BURR_CI_INTEGRATION_TESTS") == "true":
 
 @pytest.fixture
 def redis_persister():
-    persister = RedisPersister(host="localhost", port=6379, db=0)
+    persister = RedisBasePersister.from_values(host="localhost", port=6379, db=0)
     yield persister
     persister.connection.close()
 
 
 @pytest.fixture
 def redis_persister_with_ns():
-    persister = RedisPersister(host="localhost", port=6379, db=0, namespace="test")
+    persister = RedisBasePersister.from_values(host="localhost", port=6379, db=0, namespace="test")
     yield persister
     persister.connection.close()
 
@@ -61,3 +61,11 @@ def test_list_app_ids_with_ns(redis_persister_with_ns):
 def test_load_nonexistent_key_with_ns(redis_persister_with_ns):
     state_data = redis_persister_with_ns.load("pk", "nonexistent_key")
     assert state_data is None
+
+
+def test_redis_persister_class_backwards_compatible():
+    """Tests that the RedisPersister class is still backwards compatible."""
+    persister = RedisPersister(host="localhost", port=6379, db=0, namespace="backwardscompatible")
+    persister.save("pk", "app_id", 2, "pos", state.State({"a": 4, "b": 5}), "completed")
+    data = persister.load("pk", "app_id", 2)
+    assert data["state"].get_all() == {"a": 4, "b": 5}

--- a/tests/integrations/persisters/test_b_redis.py
+++ b/tests/integrations/persisters/test_b_redis.py
@@ -69,3 +69,4 @@ def test_redis_persister_class_backwards_compatible():
     persister.save("pk", "app_id", 2, "pos", state.State({"a": 4, "b": 5}), "completed")
     data = persister.load("pk", "app_id", 2)
     assert data["state"].get_all() == {"a": 4, "b": 5}
+    persister.connection.close()


### PR DESCRIPTION
This adds a new class RedisBasePersister that the old one inherits from.

The reason to do this is that if someone wants to test things, then being able to inject a mock redis client makes this simpler. So refactoring to enable that while still being backwards compatible.

Appropriately marked things as deprecated and tests have been updated.

## Changes
 - refactors redis persister

## How I tested this
 - unit tests

## Notes
- request by user to make testing simpler.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactors Redis persister by introducing `RedisBasePersister` for easier testing, deprecating `RedisPersister`, and updating tests and documentation.
> 
>   - **Refactoring**:
>     - Introduces `RedisBasePersister` class in `b_redis.py` for easier testing with mock Redis clients.
>     - `RedisPersister` now inherits from `RedisBasePersister` and is marked as deprecated.
>   - **Backward Compatibility**:
>     - `RedisPersister` class remains functional for backward compatibility.
>   - **Documentation**:
>     - Updates `persister.rst` to reference `RedisBasePersister` instead of `RedisPersister`.
>   - **Testing**:
>     - Updates tests in `test_b_redis.py` to use `RedisBasePersister`.
>     - Adds test to ensure `RedisPersister` remains backward compatible.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 428224d5d36b7b570b890a712a1353c3d245d719. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->