### PR TITLE
Refactors mongodb persister a little

### DIFF
--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -54,7 +54,7 @@ Currently we support the following, although we highly recommend you contribute 
 
    .. automethod:: __init__
 
-.. autoclass:: burr.integrations.persisters.b_mongodb.MongoDBPersister
+.. autoclass:: burr.integrations.persisters.b_mongodb.MongoDBBasePersister
    :members:
 
    .. automethod:: __init__

--- a/tests/integrations/persisters/test_b_mongodb.py
+++ b/tests/integrations/persisters/test_b_mongodb.py
@@ -11,7 +11,7 @@ if not os.environ.get("BURR_CI_INTEGRATION_TESTS") == "true":
 
 @pytest.fixture
 def mongodb_persister():
-    persister = MongoDBBasePersister(
+    persister = MongoDBBasePersister.from_values(
         uri="mongodb://localhost:27017", db_name="testdb", collection_name="testcollection"
     )
     yield persister


### PR DESCRIPTION
This is so that we can more easily test the persister, but allowing one to inject a custom client. The old way prevented that. This now then makes the behavior inline with the other persisters.

## Changes
 - mongodb persister

## How I tested this
 - unit tests

## Notes
 - to bring it up to par 

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactors MongoDB persister to allow custom client injection, introduces `MongoDBBasePersister`, and deprecates `MongoDBPersister`.
> 
>   - **Refactoring**:
>     - Introduces `MongoDBBasePersister` in `b_mongodb.py` for custom MongoDB client injection.
>     - Deprecates `MongoDBPersister`, maintaining backward compatibility.
>   - **Documentation**:
>     - Updates `persister.rst` to reference `MongoDBBasePersister`.
>   - **Testing**:
>     - Updates `test_b_mongodb.py` to use `MongoDBBasePersister`.
>     - Adds test for backward compatibility with `MongoDBPersister`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 1d26f5313cff6ba31253ec8666d94ec0e1907a4c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->