### PR TITLE
Bumps version from 0.35.0 to 0.35.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
Version bump -- haven't released 0.35, but want lineage in the commit history to work as I just fixed some bugs, jumping straight to 0.35.1 (it will have been as if we yanked 0.35.0).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps version from 0.35.0 to 0.35.1 in `pyproject.toml` to reflect bug fixes and maintain commit history lineage.
> 
>   - **Version Update**:
>     - Bumps version from 0.35.0 to 0.35.1 in `pyproject.toml` to reflect bug fixes and maintain commit history lineage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for e4d67fd12354ebb075dfc20b6e111dc63b27503f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->