### PR TITLE
Adds SERDE for persisters

### DIFF
--- a/tests/integrations/persisters/test_b_mongodb.py
+++ b/tests/integrations/persisters/test_b_mongodb.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import pytest
 
@@ -46,3 +47,21 @@ def test_backwards_compatible_persister():
     assert data["state"].get_all() == {"a": 5, "b": 5}
 
     persister.collection.drop()
+
+
+def test_serialization_with_pickle(mongodb_persister):
+    # Save some state
+    mongodb_persister.save(
+        "pk", "app_id_serde", 1, "pos", state.State({"a": 1, "b": 2}), "completed"
+    )
+
+    # Serialize the persister
+    serialized_persister = pickle.dumps(mongodb_persister)
+
+    # Deserialize the persister
+    deserialized_persister = pickle.loads(serialized_persister)
+
+    # Load the state from the deserialized persister
+    data = deserialized_persister.load("pk", "app_id_serde", 1)
+
+    assert data["state"].get_all() == {"a": 1, "b": 2}

--- a/tests/integrations/persisters/test_postgresql.py
+++ b/tests/integrations/persisters/test_postgresql.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import pytest
 
@@ -67,3 +68,21 @@ def test_is_initialized_false():
         table_name="testtable2",
     )
     assert not persister.is_initialized()
+
+
+def test_serialization_with_pickle(postgresql_persister):
+    # Save some state
+    postgresql_persister.save(
+        "pk", "app_id_serde", 1, "pos", state.State({"a": 1, "b": 2}), "completed"
+    )
+
+    # Serialize the persister
+    serialized_persister = pickle.dumps(postgresql_persister)
+
+    # Deserialize the persister
+    deserialized_persister = pickle.loads(serialized_persister)
+
+    # Load the state from the deserialized persister
+    data = deserialized_persister.load("pk", "app_id_serde", 1)
+
+    assert data["state"].get_all() == {"a": 1, "b": 2}


### PR DESCRIPTION
The persisters can now be pickled and unpickled.
This means that they can be properly serialized across process boundaries.

## Changes
- adds setstate and getstate to persisters implementations

## How I tested this
- locally for postgres
- via integration tests for others

## Notes
- this assumes the client is fixed, so if someone wants another client type, they would have to override the serde functions.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add serialization and deserialization support to MongoDB, Redis, and PostgreSQL persisters using `__getstate__` and `__setstate__`.
> 
>   - **Behavior**:
>     - Add `__getstate__` and `__setstate__` methods to `MongoDBBasePersister`, `RedisBasePersister`, and `PostgreSQLPersister` for serialization.
>     - Persisters can now be pickled and unpickled, enabling cross-process serialization.
>   - **Testing**:
>     - Add tests for serialization and deserialization using `pickle` in `test_b_mongodb.py`, `test_b_redis.py`, and `test_postgresql.py`.
>     - Tests ensure state consistency after serialization and deserialization.
>   - **Assumptions**:
>     - Assumes fixed client types for deserialization; custom clients require overriding serde functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for c5deb2ded04b85b748edb758e6d33f6b2f5a8bf4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->