### PR TITLE
Async persistance

### DIFF
--- a/burr/core/persistence.py
+++ b/burr/core/persistence.py
@@ -6,6 +6,8 @@ from abc import ABCMeta
 from collections import defaultdict
 from typing import Any, Dict, Literal, Optional, TypedDict
 
+import aiosqlite
+
 from burr.common.types import BaseCopyable
 from burr.core import Action
 from burr.core.state import State, logger
@@ -261,6 +263,30 @@ class DevNullPersister(BaseStatePersister):
         return
 
 
+class AsyncDevNullPersister(AsyncBaseStatePersister):
+    """Does nothing asynchronously, do not use this. This is for testing only."""
+
+    async def load(
+        self, partition_key: str, app_id: Optional[str], sequence_id: Optional[int] = None, **kwargs
+    ) -> Optional[PersistedStateData]:
+        return None
+
+    async def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
+        return []
+
+    async def save(
+        self,
+        partition_key: Optional[str],
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        return
+
+
 class SQLitePersister(BaseStatePersister, BaseCopyable):
     """Class for SQLite persistence of state. This is a simple implementation."""
 
@@ -476,6 +502,243 @@ class SQLitePersister(BaseStatePersister, BaseCopyable):
         )
 
 
+class AsyncSQLitePersister(AsyncBaseStatePersister, BaseCopyable):
+    """Class for asynchronous SQLite persistence of state. This is a simple implementation.
+
+    SQLite is specifically single-threaded and `aiosqlite <https://aiosqlite.omnilib.dev/en/latest/index.html>`_
+    creates async support through multi-threading. This persister is mainly here for quick prototyping and testing;
+    we suggest to consider a different database with native async support for production.
+
+    Note the third-party library `aiosqlite <https://aiosqlite.omnilib.dev/en/latest/index.html>`_,
+    is maintained and considered stable considered stable: https://github.com/omnilib/aiosqlite/issues/309.
+    """
+
+    def copy(self) -> "Self":
+        return AsyncSQLitePersister(
+            db_path=self.db_path,
+            table_name=self.table_name,
+            serde_kwargs=self.serde_kwargs,
+            connect_kwargs=self._connect_kwargs,
+        )
+
+    PARTITION_KEY_DEFAULT = ""
+
+    @classmethod
+    async def from_values(
+        cls,
+        db_path: str,
+        table_name: str = "burr_state",
+        serde_kwargs: dict = None,
+        connect_kwargs: dict = None,
+    ) -> "AsyncSQLitePersister":
+        """Creates a new instance of the AsyncSQLitePersister from passed in values.
+
+        :param db_path: the path the DB will be stored.
+        :param table_name: the table name to store things under.
+        :param serde_kwargs: kwargs for state serialization/deserialization.
+        :param connect_kwargs: kwargs to pass to the aiosqlite.connect method.
+        :return: async sqlite persister instance with an open connection. You are responsible
+            for closing the connection yourself.
+        """
+        connection = await aiosqlite.connect(
+            db_path, **connect_kwargs if connect_kwargs is not None else {}
+        )
+        return cls(connection, table_name, serde_kwargs)
+
+    def __init__(
+        self,
+        connection,
+        table_name: str = "burr_state",
+        serde_kwargs: dict = None,
+    ):
+        """Constructor.
+
+        NOTE: you are responsible to handle closing of the connection / teardown manually. To help,
+        we provide a close() method.
+
+        :param connection: the path the DB will be stored.
+        :param table_name: the table name to store things under.
+        :param serde_kwargs: kwargs for state serialization/deserialization.
+        """
+        self.connection = connection
+        self.table_name = table_name
+        self.serde_kwargs = serde_kwargs or {}
+        self._initialized = False
+
+    async def create_table_if_not_exists(self, table_name: str):
+        """Helper function to create the table where things are stored if it doesn't exist."""
+        cursor = await self.connection.cursor()
+        await cursor.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table_name} (
+                partition_key TEXT DEFAULT '{AsyncSQLitePersister.PARTITION_KEY_DEFAULT}',
+                app_id TEXT NOT NULL,
+                sequence_id INTEGER NOT NULL,
+                position TEXT NOT NULL,
+                status TEXT NOT NULL,
+                state TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (partition_key, app_id, sequence_id, position)
+            )"""
+        )
+        await cursor.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS {table_name}_created_at_index ON {table_name} (created_at);
+        """
+        )
+        await self.connection.commit()
+
+    async def initialize(self):
+        """Asynchronously creates the table if it doesn't exist"""
+        # Usage
+        await self.create_table_if_not_exists(self.table_name)
+        self._initialized = True
+
+    async def is_initialized(self) -> bool:
+        """This checks to see if the table has been created in the database or not.
+        It defaults to using the initialized field, else queries the database to see if the table exists.
+        It then sets the initialized field to True if the table exists.
+        """
+        if self._initialized:
+            return True
+
+        cursor = await self.connection.cursor()
+        await cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (self.table_name,)
+        )
+        self._initialized = await cursor.fetchone() is not None
+        return self._initialized
+
+    async def list_app_ids(self, partition_key: Optional[str] = None, **kwargs) -> list[str]:
+        partition_key = (
+            partition_key
+            if partition_key is not None
+            else AsyncSQLitePersister.PARTITION_KEY_DEFAULT
+        )
+
+        cursor = await self.connection.cursor()
+        await cursor.execute(
+            f"SELECT DISTINCT app_id FROM {self.table_name} "
+            f"WHERE partition_key = ? "
+            f"ORDER BY created_at DESC",
+            (partition_key,),
+        )
+        app_ids = [row[0] for row in await cursor.fetchall()]
+        return app_ids
+
+    async def load(
+        self,
+        partition_key: Optional[str],
+        app_id: Optional[str],
+        sequence_id: Optional[int] = None,
+        **kwargs,
+    ) -> Optional[PersistedStateData]:
+        """Asynchronously loads state for a given partition id.
+
+        Depending on the parameters, this will return the last thing written, the last thing written for a given app_id,
+        or a specific sequence_id for a given app_id.
+
+        :param partition_key:
+        :param app_id:
+        :param sequence_id:
+        :return:
+        """
+        partition_key = (
+            partition_key
+            if partition_key is not None
+            else AsyncSQLitePersister.PARTITION_KEY_DEFAULT
+        )
+        logger.debug("Loading %s, %s, %s", partition_key, app_id, sequence_id)
+        cursor = await self.connection.cursor()
+        if app_id is None:
+            # get latest for all app_ids
+            await cursor.execute(
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                f"WHERE partition_key = ? "
+                f"ORDER BY CREATED_AT DESC LIMIT 1",
+                (partition_key,),
+            )
+        elif sequence_id is None:
+            await cursor.execute(
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                f"WHERE partition_key = ? AND app_id = ? "
+                f"ORDER BY sequence_id DESC LIMIT 1",
+                (partition_key, app_id),
+            )
+        else:
+            await cursor.execute(
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                f"WHERE partition_key = ? AND app_id = ? AND sequence_id = ?",
+                (partition_key, app_id, sequence_id),
+            )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        _state = State.deserialize(json.loads(row[1]), **self.serde_kwargs)
+        return {
+            "partition_key": partition_key,
+            "app_id": row[3],
+            "sequence_id": row[2],
+            "position": row[0],
+            "state": _state,
+            "created_at": row[4],
+            "status": row[5],
+        }
+
+    async def save(
+        self,
+        partition_key: Optional[str],
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        """
+        Asynchronously saves the state for a given app_id, sequence_id, and position.
+
+        This method connects to the SQLite database, converts the state to a JSON string, and inserts a new record
+        into the table with the provided partition_key, app_id, sequence_id, position, and state. After the operation,
+        it commits the changes and closes the connection to the database.
+
+        :param partition_key: The partition key. This could be None, but it's up to the persister to whether
+            that is a valid value it can handle.
+        :param app_id: The identifier for the app instance being recorded.
+        :param sequence_id: The state corresponding to a specific point in time.
+        :param position: The position in the sequence of states.
+        :param state: The state to be saved, an instance of the State class.
+        :param status: The status of this state, either "completed" or "failed". If "failed" the state is what it was
+            before the action was applied.
+        :return: None
+        """
+        logger.debug(
+            "saving %s, %s, %s, %s, %s, %s",
+            partition_key,
+            app_id,
+            sequence_id,
+            position,
+            state,
+            status,
+        )
+        partition_key = (
+            partition_key
+            if partition_key is not None
+            else AsyncSQLitePersister.PARTITION_KEY_DEFAULT
+        )
+        cursor = await self.connection.cursor()
+        json_state = json.dumps(state.serialize(**self.serde_kwargs))
+        await cursor.execute(
+            f"INSERT INTO {self.table_name} (partition_key, app_id, sequence_id, position, state, status) "
+            f"VALUES (?, ?, ?, ?, ?, ?)",
+            (partition_key, app_id, sequence_id, position, json_state, status),
+        )
+        await self.connection.commit()
+
+    async def close(self):
+        await self.connection.close()
+
+
 class InMemoryPersister(BaseStatePersister):
     """In-memory persister for testing purposes. This is not recommended for production use."""
 
@@ -529,7 +792,61 @@ class InMemoryPersister(BaseStatePersister):
         self._storage[partition_key][app_id].append(persisted_state)
 
 
+class AsyncInMemoryPersister(AsyncBaseStatePersister):
+    """Sync in-memory persister for testing purposes. This is not recommended for production use."""
+
+    def __init__(self):
+        self._storage = defaultdict(lambda: defaultdict(list))
+
+    async def load(
+        self, partition_key: str, app_id: Optional[str], sequence_id: Optional[int] = None, **kwargs
+    ) -> Optional[PersistedStateData]:
+        # If no app_id provided, return None
+        if app_id is None:
+            return None
+
+        if not (states := self._storage[partition_key][app_id]):
+            return None
+
+        if sequence_id is None:
+            return states[-1]
+
+        # Find states matching the specific sequence_id
+        matching_states = [state for state in states if state["sequence_id"] == sequence_id]
+
+        # Return the latest state for this sequence_id, if exists
+        return matching_states[-1] if matching_states else None
+
+    async def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
+        return list(self._storage[partition_key].keys())
+
+    async def save(
+        self,
+        partition_key: Optional[str],
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        # Create a PersistedStateData entry
+        persisted_state: PersistedStateData = {
+            "partition_key": partition_key or "",
+            "app_id": app_id,
+            "sequence_id": sequence_id,
+            "position": position,
+            "state": state,
+            "created_at": datetime.datetime.now().isoformat(),
+            "status": status,
+        }
+
+        # Store the state
+        self._storage[partition_key][app_id].append(persisted_state)
+
+
 SQLLitePersister = SQLitePersister
+AsyncSQLLitePersister = AsyncSQLitePersister
 
 if __name__ == "__main__":
     s = SQLitePersister(db_path=".SQLite.db", table_name="test1")

--- a/docs/concepts/index.rst
+++ b/docs/concepts/index.rst
@@ -25,3 +25,4 @@ Overview of the concepts -- read these to get a mental model for how Burr works.
     parallelism
     recursion
     planned-capabilities
+    sync-vs-async

--- a/docs/concepts/sync-vs-async.rst
+++ b/docs/concepts/sync-vs-async.rst
@@ -1,0 +1,139 @@
+===========================
+Sync vs Async Applications
+===========================
+
+TL;DR
+------
+1. For applications with horizontal scaling: multiple users, lots of i/o throughput,... go with async. Check out:
+
+   * :py:meth:`.abuild() <.ApplicationBuilder.abuild()>`
+   * :py:meth:`.aiterate() <.Application.aiterate()>`
+   * :py:meth:`.arun() <.Application.arun()>`
+   * :py:meth:`.astream_result() <.Application.astream_result()>`
+
+2. For prototyping applications or high stakes operations,... go with sync.Check out:
+
+   * :py:meth:`.build() <.ApplicationBuilder.build()>`
+   * :py:meth:`.iterate() <.Application.iterate()>`
+   * :py:meth:`.run() <.Application.run()>`
+   * :py:meth:`.stream_result() <.Application.stream_result()>`
+
+
+Burr does both sync and async
+------------------------------
+Bellow we give a short breakdown when to consider each case.
+
+In general, Burr is equipped to handle both synchronous and asynchronous runs. We usually do that by
+providing both methods (see specific references for more detail and reach out if you feel like we
+are missing a specific implementation).
+
+We hope the switch from one to another is as convenient as possible; you only need to substitute
+functions/adapters/method calls.
+
+We highly encourage to make a decision to either commit fully to sync or async. Having said that,
+there are cases where a hybrid situation may be desirable or unavoidable (testing, prototyping,
+legacy code, ...) and we give some options to handle that. The table bellow shows the
+possibilities Burr now supports.
+
+
+.. table:: Cases Burr supports
+    :widths: auto
+
+    +------------------------------------------------+----------+----------------------------------+
+    | Cases                                          | Works?   | Comment                          |
+    +================================================+==========+==================================+
+    | Sync Hooks <> Sync Builder <> Sync App Run     |  ✅      | This is a standard use           |
+    |                                                |          | case highlighted                 |
+    |                                                |          | in sync applications             |
+    +------------------------------------------------+----------+----------------------------------+
+    | Sync Hooks <> Sync Builder <> Async App Run    |  ⚠️      | This will work for now, but it is|
+    |                                                |          | not recommended because there    |
+    |                                                |          | will be blocking functions       |
+    +------------------------------------------------+----------+----------------------------------+
+    | Async Hooks <> Sync Builder <> Sync App Run    |  ⚠️      | This will run (if the async hook |
+    |                                                |          | is not a persister), but the     |
+    |                                                |          | async hooks are ignored -- will  |
+    |                                                |          | be deprecated                    |
+    +------------------------------------------------+----------+----------------------------------+
+    | Async Hooks <> Sync Builder <> Async App Run   |  ⚠️      | This will run (if the async hook |
+    |                                                |          | is not a persister), but you     |
+    |                                                |          | should really use the async      |
+    |                                                |          | builder                          |
+    +------------------------------------------------+----------+----------------------------------+
+    | Async Hooks <> Async Builder <> Async App Run  |  ✅      | This is a standard use case      |
+    |                                                |          | highlighted       in async       |
+    |                                                |          | applications                     |
+    +------------------------------------------------+----------+----------------------------------+
+    | Async Hooks <> Async Builder <> Sync App Run   |  ❌      | Use async run methods            |
+    +------------------------------------------------+----------+----------------------------------+
+    | Sync Hooks <> Async Builder <> Sync App Run    |  ❌      | Use sync builder                 |
+    +------------------------------------------------+----------+----------------------------------+
+    | Sync Hooks <> Async Builder <> Async App Run   |  ⚠️      | This will run (if the sync hook  |
+    |                                                |          | is not a persister), but you     |
+    |                                                |          | should really use the sync       |
+    |                                                |          | builder                          |
+    +------------------------------------------------+----------+----------------------------------+
+
+
+Synchronous Applications
+--------------------------
+A synchronous application processes tasks sequentially, where the user or calling system must wait for
+the agent to finish a task before proceeding.
+
+Advantages
+~~~~~~~~~~~~
+
+1. Simplicity:
+    * Easier to design and implement as the logic flows linearly.
+    * Debugging and maintenance are more straightforward.
+2. Deterministic Behavior:
+    * Results are predictable and occur in a defined sequence.
+    * Ideal for workflows where steps must be completed in strict order.
+3. Low Overhead:
+    * Useful for tasks that don’t require extensive multitasking or background processing.
+    * Rapid prototyping.
+
+
+Use Cases
+~~~~~~~~~~~
+
+1. Short, straightforward tasks:
+    * For example, fetching a single database entry or making a quick calculation.
+2. High-stakes operations:
+    * When the process must proceed step-by-step without the risk of race conditions or overlapping tasks.
+3. Interactive applications:
+    * Situations where the user must receive immediate feedback before taking the next step, like form validations.
+
+Asynchronous Application
+--------------------------
+An asynchronous application can perform tasks in parallel or handle multiple requests without waiting for
+one to finish before starting another.
+
+Advantages
+~~~~~~~~~~~~
+
+1. Efficiency:
+    * Makes better use of system resources by handling multiple tasks simultaneously.
+    * Reduces idle time, especially when dealing with I/O-bound or network-bound operations.
+2. Scalability:
+    * Handles large volumes of concurrent tasks more effectively.
+    * Useful in systems requiring high throughput, like web servers or chatbots.
+3. Non-blocking Execution:
+    * Allows other operations to continue while waiting for longer processes to complete.
+    * Provides a smoother experience in real-time systems.
+
+
+Use Cases
+~~~~~~~~~~~~
+
+1. Long-running processes:
+    * Training machine learning models.
+    * Data processing pipelines.
+2. I/O-bound tasks:
+    * Calling APIs.
+    * Retrieving data from remote servers or databases.
+3. High-concurrency systems:
+    * Chatbots serving multiple users.
+    * Customer support systems.
+4. Background processing:
+    * Notifications, logs, and analytics tasks running while the main application continues.

--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -30,8 +30,8 @@ Internally, this interface combines the following two interfaces:
     .. automethod:: __init__
 
 
-Supported Implementations
-=========================
+Supported Sync Implementations
+================================
 
 .. _persistersref:
 
@@ -61,3 +61,16 @@ Currently we support the following, although we highly recommend you contribute 
 
 Note that the :py:class:`LocalTrackingClient <burr.tracking.client.LocalTrackingClient>` leverages the :py:class:`BaseStateLoader <burr.core.persistence.BaseStateLoader>` to allow loading state,
 although it uses different mechanisms to save state (as it tracks more than just state).
+
+
+Supported Async Implementations
+================================
+
+Currently we support the following, although we highly recommend you contribute your own! We will be adding more shortly.
+
+.. _asyncpersistersref:
+
+.. autoclass:: burr.core.persistence.AsyncSQLitePersister
+   :members:
+
+   .. automethod:: __init__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ streamlit = [
   "streamlit",
   "graphviz",
   "matplotlib",
-  "sf-hamilton"
+  "sf-hamilton",
 ]
 
 hamilton = [
@@ -38,6 +38,10 @@ hamilton = [
 
 graphviz = [
   "graphviz"
+]
+
+sqlite = [
+  "aiosqlite"
 ]
 
 postgresql = [
@@ -61,6 +65,7 @@ tests = [
   "pydantic[email]",
   "pyarrow",
   "redis",
+  "aiosqlite",
   "burr[opentelemetry]",
   "burr[haystack]",
   "burr[ray]"
@@ -77,6 +82,7 @@ documentation = [
   "psycopg2-binary",
   "redis",
   "ray",
+  "aiosqlite",
   "sphinxcontrib-googleanalytics"
 ]
 

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -1,7 +1,16 @@
+import asyncio
+from typing import Tuple
+
+import aiosqlite
 import pytest
 
-from burr.core import State
-from burr.core.persistence import InMemoryPersister, SQLLitePersister
+from burr.core import ApplicationBuilder, State, action
+from burr.core.persistence import (
+    AsyncInMemoryPersister,
+    AsyncSQLLitePersister,
+    InMemoryPersister,
+    SQLLitePersister,
+)
 
 
 @pytest.fixture(
@@ -98,3 +107,256 @@ def test_persister_methods_none_partition_key(persistence, method_name: str, kwa
     # this doesn't guarantee that the results of `partition_key=None` and
     # `partition_key=persistence.PARTITION_KEY_DEFAULT`. This is hard to test because
     # these operations are stateful (i.e., read/write to a db)
+
+
+class AsyncSQLLiteContextManager:
+    def __init__(self, sqlite_object):
+        self.client = sqlite_object
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.client.close()
+
+
+@pytest.fixture(
+    params=[
+        {"which": "sqlite"},
+        {"which": "memory"},
+    ]
+)
+async def async_persistence(request):
+    which = request.param["which"]
+    if which == "sqlite":
+        sqlite_persister = await AsyncSQLLitePersister.from_values(
+            db_path=":memory:", table_name="test_table"
+        )
+        async_context_manager = AsyncSQLLiteContextManager(sqlite_persister)
+        async with async_context_manager as client:
+            yield client
+    elif which == "memory":
+        yield AsyncInMemoryPersister()
+
+
+async def test_async_persistence_saves_and_loads_state(async_persistence):
+    await asyncio.sleep(0.00001)
+    if hasattr(async_persistence, "initialize"):
+        await async_persistence.initialize()
+    await async_persistence.save(
+        "partition_key", "app_id", 1, "position", State({"key": "value"}), "status"
+    )
+    loaded_state = await async_persistence.load("partition_key", "app_id")
+    assert loaded_state["state"] == State({"key": "value"})
+
+
+async def test_async_persistence_returns_none_when_no_state(async_persistence):
+    await asyncio.sleep(0.00001)
+    if hasattr(async_persistence, "initialize"):
+        await async_persistence.initialize()
+    loaded_state = await async_persistence.load("partition_key", "app_id")
+    assert loaded_state is None
+
+
+async def test_async_persistence_lists_app_ids(async_persistence):
+    await asyncio.sleep(0.00001)
+    if hasattr(async_persistence, "initialize"):
+        await async_persistence.initialize()
+    await async_persistence.save(
+        "partition_key", "app_id1", 1, "position", State({"key": "value"}), "status"
+    )
+    await async_persistence.save(
+        "partition_key", "app_id2", 1, "position", State({"key": "value"}), "status"
+    )
+    app_ids = await async_persistence.list_app_ids("partition_key")
+    assert set(app_ids) == set(["app_id1", "app_id2"])
+
+
+@pytest.mark.parametrize(
+    "method_name,kwargs",
+    [
+        ("list_app_ids", {"partition_key": None}),
+        ("load", {"partition_key": None, "app_id": "foo"}),
+        (
+            "save",
+            {
+                "partition_key": None,
+                "app_id": "foo",
+                "sequence_id": 1,
+                "position": "position",
+                "state": State({"key": "value"}),
+                "status": "status",
+            },
+        ),
+    ],
+)
+async def test_async_persister_methods_none_partition_key(
+    async_persistence, method_name: str, kwargs: dict
+):
+    await asyncio.sleep(0.00001)
+    if hasattr(async_persistence, "initialize"):
+        await async_persistence.initialize()
+    method = getattr(async_persistence, method_name)
+    # method can be executed with `partition_key=None`
+    await method(**kwargs)
+    # this doesn't guarantee that the results of `partition_key=None` and
+    # `partition_key=persistence.PARTITION_KEY_DEFAULT`. This is hard to test because
+    # these operations are stateful (i.e., read/write to a db)
+
+
+async def test_AsyncSQLLitePersister_from_values():
+    await asyncio.sleep(0.00001)
+    connection = await aiosqlite.connect(":memory:")
+    sqlite_persister_init = AsyncSQLLitePersister(connection=connection, table_name="test_table")
+    sqlite_persister_from_values = await AsyncSQLLitePersister.from_values(
+        db_path=":memory:", table_name="test_table"
+    )
+
+    try:
+        sqlite_persister_init.connection == sqlite_persister_from_values.connection
+    except Exception as e:
+        raise e
+    finally:
+        await sqlite_persister_init.close()
+        await sqlite_persister_from_values.close()
+
+
+async def test_AsyncSQLLitePersister_connection_shutdown():
+    await asyncio.sleep(0.00001)
+    sqlite_persister = await AsyncSQLLitePersister.from_values(
+        db_path=":memory:", table_name="test_table"
+    )
+    await sqlite_persister.close()
+
+
+@pytest.fixture()
+async def initializing_async_persistence():
+    sqlite_persister = await AsyncSQLLitePersister.from_values(
+        db_path=":memory:", table_name="test_table"
+    )
+    async_context_manager = AsyncSQLLiteContextManager(sqlite_persister)
+    async with async_context_manager as client:
+        yield client
+
+
+async def test_async_persistence_initialization_creates_table(initializing_async_persistence):
+    await asyncio.sleep(0.00001)
+    await initializing_async_persistence.initialize()
+    assert await initializing_async_persistence.list_app_ids("partition_key") == []
+
+
+async def test_async_persistence_is_initialized_false(initializing_async_persistence):
+    await asyncio.sleep(0.00001)
+    assert not await initializing_async_persistence.is_initialized()
+
+
+async def test_async_persistence_is_initialized_true(initializing_async_persistence):
+    await asyncio.sleep(0.00001)
+    await initializing_async_persistence.initialize()
+    assert await initializing_async_persistence.is_initialized()
+
+
+async def test_asyncsqlite_persistence_is_initialized_true_new_connection(tmp_path):
+    await asyncio.sleep(0.00001)
+    db_path = tmp_path / "test.db"
+    p = await AsyncSQLLitePersister.from_values(db_path=db_path, table_name="test_table")
+    await p.initialize()
+    p2 = await AsyncSQLLitePersister.from_values(db_path=db_path, table_name="test_table")
+    try:
+        assert await p.is_initialized()
+        assert await p2.is_initialized()
+    except Exception as e:
+        raise e
+    finally:
+        await p.close()
+        await p2.close()
+
+
+async def test_async_save_and_load_from_sqlite_persister_end_to_end(tmp_path):
+    await asyncio.sleep(0.00001)
+
+    @action(reads=[], writes=["prompt", "chat_history"])
+    async def dummy_input(state: State) -> Tuple[dict, State]:
+        await asyncio.sleep(0.0001)
+        if state["chat_history"]:
+            new = state["chat_history"][-1] + 1
+        else:
+            new = 1
+        return (
+            {"prompt": "PROMPT"},
+            state.update(prompt="PROMPT").append(chat_history=new),
+        )
+
+    @action(reads=["chat_history"], writes=["response", "chat_history"])
+    async def dummy_response(state: State) -> Tuple[dict, State]:
+        await asyncio.sleep(0.0001)
+        if state["chat_history"]:
+            new = state["chat_history"][-1] + 1
+        else:
+            new = 1
+        return (
+            {"response": "RESPONSE"},
+            state.update(response="RESPONSE").append(chat_history=new),
+        )
+
+    db_path = tmp_path / "test.db"
+    sqlite_persister = await AsyncSQLLitePersister.from_values(
+        db_path=db_path, table_name="test_table"
+    )
+    await sqlite_persister.initialize()
+    app = await (
+        ApplicationBuilder()
+        .with_actions(dummy_input, dummy_response)
+        .with_transitions(("dummy_input", "dummy_response"), ("dummy_response", "dummy_input"))
+        .initialize_from(
+            initializer=sqlite_persister,
+            resume_at_next_action=True,
+            default_state={"chat_history": []},
+            default_entrypoint="dummy_input",
+        )
+        .with_state_persister(sqlite_persister)
+        .with_identifiers(app_id="test_1", partition_key="sqlite")
+        .abuild()
+    )
+
+    try:
+        *_, state = await app.arun(halt_after=["dummy_response"])
+        assert state["chat_history"][0] == 1
+        assert state["chat_history"][1] == 2
+        del app
+    except Exception as e:
+        raise e
+    finally:
+        await sqlite_persister.close()
+        del sqlite_persister
+
+    sqlite_persister_2 = await AsyncSQLLitePersister.from_values(
+        db_path=db_path, table_name="test_table"
+    )
+    await sqlite_persister_2.initialize()
+    new_app = await (
+        ApplicationBuilder()
+        .with_actions(dummy_input, dummy_response)
+        .with_transitions(("dummy_input", "dummy_response"), ("dummy_response", "dummy_input"))
+        .initialize_from(
+            initializer=sqlite_persister_2,
+            resume_at_next_action=True,
+            default_state={"chat_history": []},
+            default_entrypoint="dummy_input",
+        )
+        .with_state_persister(sqlite_persister_2)
+        .with_identifiers(app_id="test_1", partition_key="sqlite")
+        .abuild()
+    )
+
+    try:
+        assert new_app.state["chat_history"][0] == 1
+        assert new_app.state["chat_history"][1] == 2
+
+        *_, state = await new_app.arun(halt_after=["dummy_response"])
+        assert state["chat_history"][2] == 3
+        assert state["chat_history"][3] == 4
+    except Exception as e:
+        raise e
+    finally:
+        await sqlite_persister_2.close()


### PR DESCRIPTION
Addressing #484 to have an async persistence interface.

## Changes
- Adds base classes for saving/loading/running persistor in application via async
- Adds async initializer/persister to ApplicationBuilder and lets us build async Application via `.abuild()`
- Adds async validation to Application to warn about async hook being ignored in sync runs and raises error if you try to do sync run with an async Application.
- Adds create_async_app in parallelism to create application via AsyncApplicationBuilder (in case of legacy use of sync initializer/persister reverts to old sync Application)
- TBD: database specific implementations (only AsyncDevNullPersister for testing)

To think about: (1) fire-and-forget or (2) blocking/transactional options -- 
Async persistors are naturally (1) and sync persistors are (2). If we want to have both options for both cases, we need to:
- effectively block the async save to turn (1)->(2) and 
- create an event loop / another tread and make sync save a coroutine executing there to go from (2) -> (1).  
My initial idea was to have that option as an attribute of the persistor class and handle it within PersisterHook/PersisterHookAsync, but still checking if there is a more natural place for this.


## How I tested this
- Unit and E2E

## Notes
This part is very much for discussion if we want to have another `AsyncApplicationBuilder` or put this into the existing `ApplicationBuilder`. My arguments for having two:
1. It is cleaner to separate async and sync (and maybe less error-prone to use the wrong one?).
2. There are 3 methods we need to define async: `with_state_persister`, `_load_from_persister`, and `build`. 
3. Related to the above, if `with_state_persister` is async it gets a bit hairy how to do method chaining -- what I did is to overwrite the original method to just store the state_persister (similar to what `initialize_from` does) and then pushed all the logic into an async helper function `__with_async_state_persister` that gets awaited in `build` to manually chain coroutines.
4. Having another builder class made it clearer also in the Application class to raise an error when `run` is used instead of `arun`.

Having said all of that, I also can push those methods into the existing builder with an `abuild()` to follow the pattern in the Application class where both sync and async are side-by-side.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add asynchronous persistence support with `AsyncApplicationBuilder` and related async classes and tests.
> 
>   - **Behavior**:
>     - Introduces `AsyncApplicationBuilder` to support asynchronous state persistence.
>     - Adds `create_async_app` in `parallelism.py` for async application creation.
>     - Implements `AsyncDevNullPersister` for testing async persistence.
>   - **Persistence**:
>     - Adds `AsyncBaseStateLoader` and `AsyncBaseStateSaver` in `persistence.py` for async state operations.
>     - Introduces `PersisterHookAsync` for async lifecycle hooks.
>   - **Testing**:
>     - Adds tests for async persistence in `test_application.py`, including `test_async_save_and_load_from_persister_end_to_end`.
>   - **Misc**:
>     - Updates imports in `__init__.py` and `application.py` to include async classes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 9e233c887482dd04ee96662b3cd8bc739f8f1a72. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->