### PR TITLE
Version bump 0.37.0

### DIFF
--- a/docs/concepts/parallelism.rst
+++ b/docs/concepts/parallelism.rst
@@ -621,6 +621,10 @@ Notes
 =====
 
 This is in an experimental release phase. While we anticipate the API to be stable, we reserve the right to make slight changes (and will obviously add new features).
+Caveats:
+
+1. Parallelism does not work with typed state (yet) -- we aim to fix this to work soon, but do not rely on sub-actions or parallel actions working together with typed state yet.
+
 
 Things that may change:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "burr"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
Version bump + quick docs caveat
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Version bump to 0.37.0 and add documentation caveat about parallelism limitations with typed state.
> 
>   - **Versioning**:
>     - Bump version from `0.36.1` to `0.37.0` in `pyproject.toml`.
>   - **Documentation**:
>     - Add caveat in `parallelism.rst` about parallelism not working with typed state yet.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for fcaca22cff4df02a4e317bd4111b41c2fcb88caa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->