### PR TITLE
Async db support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           pip install -e ".[documentation]"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install -e ".[tests]"

--- a/burr/integrations/persisters/b_asyncpg.py
+++ b/burr/integrations/persisters/b_asyncpg.py
@@ -1,0 +1,264 @@
+from burr.integrations import base
+
+try:
+    import asyncpg
+except ImportError as e:
+    base.require_plugin(e, "asyncpg")
+
+import json
+import logging
+from typing import Literal, Optional
+
+from burr.core import persistence, state
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
+    """Class for async PostgreSQL persistence of state.
+
+    .. warning::
+        The synchronous persister closes the connection on deletion of the class using the ``__del__`` method.
+        In an async context that is not reliable (the event loop may already be closed by the time ``__del__``
+        gets invoked). Therefore, you are responsible for closing the connection yourself (i.e. manual cleanup).
+        We suggest to use the persister either as a context manager through the ``async with`` clause or
+        using the method ``.cleanup()``.
+
+    .. note::
+        The implementation relies on the popular asyncpg library: https://github.com/MagicStack/asyncpg
+
+        MagicStack wrote a blog post: http://magic.io/blog/asyncpg-1m-rows-from-postgres-to-python/
+        explaining why a new implementation, performance review and comparison to aiopg (async interface of psycopg2).
+
+
+    To try it out locally with docker -- here's a command -- change the values as appropriate.
+
+    .. code:: bash
+
+        docker run --name local-psql \  # container name
+                   -v local_psql_data:/SOME/FILE_PATH/ \  # mounting a volume for data persistence
+                   -p 54320:5432 \  # port mapping
+                   -e POSTGRES_PASSWORD=my_password \  # superuser password
+                   -d postgres  # database name
+
+    Then you should be able to create the class like this:
+
+    .. code:: python
+
+        p = await AsyncPostgreSQLPersister.from_values("postgres", "postgres", "my_password",
+                                           "localhost", 54320, table_name="burr_state")
+
+
+    """
+
+    PARTITION_KEY_DEFAULT = ""
+
+    @classmethod
+    async def from_config(cls, config: dict) -> "AsyncPostgreSQLPersister":
+        """Creates a new instance of the PostgreSQLPersister from a configuration dictionary."""
+        return await cls.from_values(**config)
+
+    @classmethod
+    async def from_values(
+        cls,
+        db_name: str,
+        user: str,
+        password: str,
+        host: str,
+        port: int,
+        table_name: str = "burr_state",
+    ) -> "AsyncPostgreSQLPersister":
+        """Builds a new instance of the PostgreSQLPersister from the provided values.
+
+        :param db_name: the name of the PostgreSQL database.
+        :param user: the username to connect to the PostgreSQL database.
+        :param password: the password to connect to the PostgreSQL database.
+        :param host: the host of the PostgreSQL database.
+        :param port: the port of the PostgreSQL database.
+        :param table_name:  the table name to store things under.
+        """
+        connection = await asyncpg.connect(
+            user=user, password=password, database=db_name, host=host, port=port
+        )
+        return cls(connection, table_name)
+
+    def __init__(self, connection, table_name: str = "burr_state", serde_kwargs: dict = None):
+        """Constructor
+
+        :param connection: the connection to the PostgreSQL database.
+        :param table_name:  the table name to store things under.
+        """
+        self.table_name = table_name
+        self.connection = connection
+        self.serde_kwargs = serde_kwargs or {}
+        self._initialized = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.connection.close()
+        return False
+
+    def set_serde_kwargs(self, serde_kwargs: dict):
+        """Sets the serde_kwargs for the persister."""
+        self.serde_kwargs = serde_kwargs
+
+    async def create_table(self, table_name: str):
+        """Helper function to create the table where things are stored."""
+        async with self.connection.transaction():
+            await self.connection.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {table_name} (
+                    partition_key TEXT DEFAULT '{self.PARTITION_KEY_DEFAULT}',
+                    app_id TEXT NOT NULL,
+                    sequence_id INTEGER NOT NULL,
+                    position TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    state JSONB NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (partition_key, app_id, sequence_id, position)
+                )"""
+            )
+            await self.connection.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS {table_name}_created_at_index ON {table_name} (created_at);
+            """
+            )
+
+    async def initialize(self):
+        """Creates the table"""
+        await self.create_table(self.table_name)
+        self._initialized = True
+
+    async def is_initialized(self) -> bool:
+        """This checks to see if the table has been created in the database or not.
+        It defaults to using the initialized field, else queries the database to see if the table exists.
+        It then sets the initialized field to True if the table exists.
+        """
+        if self._initialized:
+            return True
+
+        query = "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $1)"
+        self._initialized = await self.connection.fetchval(query, self.table_name, column=0)
+        return self._initialized
+
+    async def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
+        """Lists the app_ids for a given partition_key."""
+        query = (
+            f"SELECT DISTINCT app_id, created_at FROM {self.table_name} "
+            "WHERE partition_key = $1 "
+            "ORDER BY created_at DESC"
+        )
+        fetched_data = await self.connection.fetch(query, partition_key)
+        app_ids = [row[0] for row in fetched_data]
+        return app_ids
+
+    async def load(
+        self, partition_key: Optional[str], app_id: str, sequence_id: int = None, **kwargs
+    ) -> Optional[persistence.PersistedStateData]:
+        """Loads state for a given partition id.
+
+        Depending on the parameters, this will return the last thing written, the last thing written for a given app_id,
+        or a specific sequence_id for a given app_id.
+
+        :param partition_key:
+        :param app_id:
+        :param sequence_id:
+        :return:
+        """
+        if partition_key is None:
+            partition_key = self.PARTITION_KEY_DEFAULT
+        logger.debug("Loading %s, %s, %s", partition_key, app_id, sequence_id)
+
+        if app_id is None:
+            # get latest for all app_ids
+            query = (
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                "WHERE partition_key = $1 "
+                f"ORDER BY CREATED_AT DESC LIMIT 1"
+            )
+            row = await self.connection.fetchrow(query, partition_key)
+
+        elif sequence_id is None:
+            query = (
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                "WHERE partition_key = $1 AND app_id = $2 "
+                f"ORDER BY sequence_id DESC LIMIT 1"
+            )
+            row = await self.connection.fetchrow(query, partition_key, app_id)
+        else:
+            query = (
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                "WHERE partition_key = $1 AND app_id = $2 AND sequence_id = $3 "
+            )
+            row = await self.connection.fetchrow(
+                query,
+                partition_key,
+                app_id,
+                sequence_id,
+            )
+        if row is None:
+            return None
+        # converts from asyncpg str to dict
+        json_row = json.loads(row[1])
+        _state = state.State.deserialize(json_row, **self.serde_kwargs)
+        return {
+            "partition_key": partition_key,
+            "app_id": row[3],
+            "sequence_id": row[2],
+            "position": row[0],
+            "state": _state,
+            "created_at": row[4],
+            "status": row[5],
+        }
+
+    async def save(
+        self,
+        partition_key: str,
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: state.State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        """
+        Saves the state for a given app_id, sequence_id, and position.
+
+        This method connects to the SQLite database, converts the state to a JSON string, and inserts a new record
+        into the table with the provided partition_key, app_id, sequence_id, position, and state. After the operation,
+        it commits the changes and closes the connection to the database.
+
+        :param partition_key: The partition key. This could be None, but it's up to the persistor to whether
+            that is a valid value it can handle.
+        :param app_id: The identifier for the app instance being recorded.
+        :param sequence_id: The state corresponding to a specific point in time.
+        :param position: The position in the sequence of states.
+        :param state: The state to be saved, an instance of the State class.
+        :param status: The status of this state, either "completed" or "failed". If "failed" the state is what it was
+            before the action was applied.
+        :return: None
+        """
+        logger.debug(
+            "saving %s, %s, %s, %s, %s, %s",
+            partition_key,
+            app_id,
+            sequence_id,
+            position,
+            state,
+            status,
+        )
+
+        json_state = json.dumps(state.serialize(**self.serde_kwargs))
+        query = (
+            f"INSERT INTO {self.table_name} (partition_key, app_id, sequence_id, position, state, status) "
+            "VALUES ($1, $2, $3, $4, $5, $6)"
+        )
+        await self.connection.execute(
+            query, partition_key, app_id, sequence_id, position, json_state, status
+        )
+
+    async def cleanup(self):
+        """Closes the connection to the database."""
+        await self.connection.close()

--- a/burr/integrations/persisters/b_mongodb.py
+++ b/burr/integrations/persisters/b_mongodb.py
@@ -1,38 +1,23 @@
-import json
+"""This module will be deprecated. Please use b_pymongo.py for imports."""
+
 import logging
-from datetime import datetime, timezone
-from typing import Literal, Optional
 
 from pymongo import MongoClient
 
-from burr.core import persistence, state
+from burr.integrations.persisters.b_pymongo import MongoDBBasePersister as PymongoPersister
 
 logger = logging.getLogger(__name__)
 
+logger.warning(
+    "This class is deprecated and has been moved. "
+    "Please import MongoDBBasePersister from b_pymongo.py."
+)
 
-class MongoDBBasePersister(persistence.BaseStatePersister):
-    """A class used to represent a MongoDB Persister.
 
-    Example usage:
+class MongoDBBasePersister(PymongoPersister):
+    """A class used to represent the MongoDB Persister.
 
-    .. code-block:: python
-
-       persister = MongoDBBasePersister.from_values(uri='mongodb://user:pass@localhost:27017',
-                                                    db_name='mydatabase',
-                                                    collection_name='mystates')
-       persister.save(
-           partition_key='example_partition',
-           app_id='example_app',
-           sequence_id=1,
-           position='example_position',
-           state=state.State({'key': 'value'}),
-           status='completed'
-       )
-       loaded_state = persister.load(partition_key='example_partition', app_id='example_app', sequence_id=1)
-       print(loaded_state)
-
-    Note: this is called MongoDBBasePersister because we had to change the constructor and wanted to make
-     this change backwards compatible.
+    This class is deprecated and has been moved to b_pymongo.py.
     """
 
     @classmethod
@@ -45,114 +30,19 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
         mongo_client_kwargs: dict = None,
     ) -> "MongoDBBasePersister":
         """Initializes the MongoDBBasePersister class."""
+
         if mongo_client_kwargs is None:
             mongo_client_kwargs = {}
         client = MongoClient(uri, **mongo_client_kwargs)
-        return cls(
+        return PymongoPersister(
             client=client,
             db_name=db_name,
             collection_name=collection_name,
             serde_kwargs=serde_kwargs,
         )
 
-    def __init__(
-        self,
-        client,
-        db_name="mydatabase",
-        collection_name="mystates",
-        serde_kwargs: dict = None,
-    ):
-        """Initializes the MongoDBBasePersister class.
 
-        :param client: the mongodb client to use
-        :param db_name: the name of the database to use
-        :param collection_name: the name of the collection to use
-        :param serde_kwargs: serializer/deserializer keyword arguments to pass to the state object
-        """
-        self.client = client
-        self.db = self.client[db_name]
-        self.collection = self.db[collection_name]
-        self.serde_kwargs = serde_kwargs or {}
-
-    def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
-        """List the app ids for a given partition key."""
-        app_ids = self.collection.distinct("app_id", {"partition_key": partition_key})
-        return app_ids
-
-    def load(
-        self, partition_key: str, app_id: str, sequence_id: int = None, **kwargs
-    ) -> Optional[persistence.PersistedStateData]:
-        """Load the state data for a given partition key, app id, and sequence id."""
-        query = {"partition_key": partition_key, "app_id": app_id}
-        if sequence_id is not None:
-            query["sequence_id"] = sequence_id
-        document = self.collection.find_one(query, sort=[("sequence_id", -1)])
-        if not document:
-            return None
-        _state = state.State.deserialize(json.loads(document["state"]), **self.serde_kwargs)
-        return {
-            "partition_key": partition_key,
-            "app_id": app_id,
-            "sequence_id": document["sequence_id"],
-            "position": document["position"],
-            "state": _state,
-            "created_at": document["created_at"],
-            "status": document["status"],
-        }
-
-    def save(
-        self,
-        partition_key: str,
-        app_id: str,
-        sequence_id: int,
-        position: str,
-        state: state.State,
-        status: Literal["completed", "failed"],
-        **kwargs,
-    ):
-        """Save the state data to the MongoDB database."""
-        key = {"partition_key": partition_key, "app_id": app_id, "sequence_id": sequence_id}
-        if self.collection.find_one(key):
-            raise ValueError(f"partition_key:app_id:sequence_id[{key}] already exists.")
-        json_state = json.dumps(state.serialize(**self.serde_kwargs))
-        self.collection.insert_one(
-            {
-                "partition_key": partition_key,
-                "app_id": app_id,
-                "sequence_id": sequence_id,
-                "position": position,
-                "state": json_state,
-                "status": status,
-                "created_at": datetime.now(timezone.utc).isoformat(),
-            }
-        )
-
-    def __del__(self):
-        self.client.close()
-
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        state["connection_params"] = {
-            "uri": self.client.address[0],
-            "port": self.client.address[1],
-            "db_name": self.db.name,
-            "collection_name": self.collection.name,
-        }
-        del state["client"]
-        del state["db"]
-        del state["collection"]
-        return state
-
-    def __setstate__(self, state: dict):
-        connection_params = state.pop("connection_params")
-        # we assume MongoClient.
-        self.client = MongoClient(connection_params["uri"], connection_params["port"])
-        self.db = self.client[connection_params["db_name"]]
-        self.collection = self.db[connection_params["collection_name"]]
-        self.__dict__.update(state)
-
-
-class MongoDBPersister(MongoDBBasePersister):
+class MongoDBPersister(PymongoPersister):
     """A class used to represent a MongoDB Persister.
 
     This class is deprecated. Please use MongoDBBasePersister instead.

--- a/burr/integrations/persisters/b_psycopg2.py
+++ b/burr/integrations/persisters/b_psycopg2.py
@@ -1,0 +1,290 @@
+from burr.integrations import base
+
+try:
+    import psycopg2
+except ImportError as e:
+    base.require_plugin(e, "postgresql")
+
+import json
+import logging
+from typing import Literal, Optional
+
+from burr.core import persistence, state
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLPersister(persistence.BaseStatePersister):
+    """Class for PostgreSQL persistence of state. This is a simple implementation.
+
+    To try it out locally with docker -- here's a command -- change the values as appropriate.
+
+    .. code:: bash
+
+        docker run --name local-psql \  # container name
+                   -v local_psql_data:/SOME/FILE_PATH/ \  # mounting a volume for data persistence
+                   -p 54320:5432 \  # port mapping
+                   -e POSTGRES_PASSWORD=my_password \  # superuser password
+                   -d postgres  # database name
+
+    Then you should be able to create the class like this:
+
+    .. code:: python
+
+        p = PostgreSQLPersister.from_values("postgres", "postgres", "my_password",
+                                           "localhost", 54320, table_name="burr_state")
+
+
+    """
+
+    PARTITION_KEY_DEFAULT = ""
+
+    @classmethod
+    def from_config(cls, config: dict) -> "PostgreSQLPersister":
+        """Creates a new instance of the PostgreSQLPersister from a configuration dictionary."""
+        return cls.from_values(**config)
+
+    @classmethod
+    def from_values(
+        cls,
+        db_name: str,
+        user: str,
+        password: str,
+        host: str,
+        port: int,
+        table_name: str = "burr_state",
+    ):
+        """Builds a new instance of the PostgreSQLPersister from the provided values.
+
+        :param db_name: the name of the PostgreSQL database.
+        :param user: the username to connect to the PostgreSQL database.
+        :param password: the password to connect to the PostgreSQL database.
+        :param host: the host of the PostgreSQL database.
+        :param port: the port of the PostgreSQL database.
+        :param table_name:  the table name to store things under.
+        """
+        connection = psycopg2.connect(
+            dbname=db_name, user=user, password=password, host=host, port=port
+        )
+        return cls(connection, table_name)
+
+    def __init__(self, connection, table_name: str = "burr_state", serde_kwargs: dict = None):
+        """Constructor
+
+        :param connection: the connection to the PostgreSQL database.
+        :param table_name:  the table name to store things under.
+        """
+        self.table_name = table_name
+        self.connection = connection
+        self.serde_kwargs = serde_kwargs or {}
+        self._initialized = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.connection.close()
+        return False
+
+    def set_serde_kwargs(self, serde_kwargs: dict):
+        """Sets the serde_kwargs for the persister."""
+        self.serde_kwargs = serde_kwargs
+
+    def create_table(self, table_name: str):
+        """Helper function to create the table where things are stored."""
+        cursor = self.connection.cursor()
+        cursor.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table_name} (
+                partition_key TEXT DEFAULT '{self.PARTITION_KEY_DEFAULT}',
+                app_id TEXT NOT NULL,
+                sequence_id INTEGER NOT NULL,
+                position TEXT NOT NULL,
+                status TEXT NOT NULL,
+                state JSONB NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (partition_key, app_id, sequence_id, position)
+            )"""
+        )
+        cursor.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS {table_name}_created_at_index ON {table_name} (created_at);
+        """
+        )
+        self.connection.commit()
+
+    def initialize(self):
+        """Creates the table"""
+        self.create_table(self.table_name)
+        self._initialized = True
+
+    def is_initialized(self) -> bool:
+        """This checks to see if the table has been created in the database or not.
+        It defaults to using the initialized field, else queries the database to see if the table exists.
+        It then sets the initialized field to True if the table exists.
+        """
+        if self._initialized:
+            return True
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
+            (self.table_name,),
+        )
+        self._initialized = cursor.fetchone()[0]
+        return self._initialized
+
+    def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
+        """Lists the app_ids for a given partition_key."""
+        cursor = self.connection.cursor()
+        cursor.execute(
+            f"SELECT DISTINCT app_id, created_at FROM {self.table_name} "
+            "WHERE partition_key = %s "
+            "ORDER BY created_at DESC",
+            (partition_key,),
+        )
+        app_ids = [row[0] for row in cursor.fetchall()]
+        return app_ids
+
+    def load(
+        self, partition_key: Optional[str], app_id: str, sequence_id: int = None, **kwargs
+    ) -> Optional[persistence.PersistedStateData]:
+        """Loads state for a given partition id.
+
+        Depending on the parameters, this will return the last thing written, the last thing written for a given app_id,
+        or a specific sequence_id for a given app_id.
+
+        :param partition_key:
+        :param app_id:
+        :param sequence_id:
+        :return:
+        """
+        if partition_key is None:
+            partition_key = self.PARTITION_KEY_DEFAULT
+        logger.debug("Loading %s, %s, %s", partition_key, app_id, sequence_id)
+        cursor = self.connection.cursor()
+        if app_id is None:
+            # get latest for all app_ids
+            cursor.execute(
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                f"WHERE partition_key = %s "
+                f"ORDER BY CREATED_AT DESC LIMIT 1",
+                (partition_key,),
+            )
+        elif sequence_id is None:
+            cursor.execute(
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                f"WHERE partition_key = %s AND app_id = %s "
+                f"ORDER BY sequence_id DESC LIMIT 1",
+                (partition_key, app_id),
+            )
+        else:
+            cursor.execute(
+                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                f"WHERE partition_key = %s AND app_id = %s AND sequence_id = %s ",
+                (partition_key, app_id, sequence_id),
+            )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        _state = state.State.deserialize(row[1], **self.serde_kwargs)
+        return {
+            "partition_key": partition_key,
+            "app_id": row[3],
+            "sequence_id": row[2],
+            "position": row[0],
+            "state": _state,
+            "created_at": row[4],
+            "status": row[5],
+        }
+
+    def save(
+        self,
+        partition_key: str,
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: state.State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        """
+        Saves the state for a given app_id, sequence_id, and position.
+
+        This method connects to the SQLite database, converts the state to a JSON string, and inserts a new record
+        into the table with the provided partition_key, app_id, sequence_id, position, and state. After the operation,
+        it commits the changes and closes the connection to the database.
+
+        :param partition_key: The partition key. This could be None, but it's up to the persistor to whether
+            that is a valid value it can handle.
+        :param app_id: The identifier for the app instance being recorded.
+        :param sequence_id: The state corresponding to a specific point in time.
+        :param position: The position in the sequence of states.
+        :param state: The state to be saved, an instance of the State class.
+        :param status: The status of this state, either "completed" or "failed". If "failed" the state is what it was
+            before the action was applied.
+        :return: None
+        """
+        logger.debug(
+            "saving %s, %s, %s, %s, %s, %s",
+            partition_key,
+            app_id,
+            sequence_id,
+            position,
+            state,
+            status,
+        )
+        cursor = self.connection.cursor()
+        json_state = json.dumps(state.serialize(**self.serde_kwargs))
+        cursor.execute(
+            f"INSERT INTO {self.table_name} (partition_key, app_id, sequence_id, position, state, status) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            (partition_key, app_id, sequence_id, position, json_state, status),
+        )
+        self.connection.commit()
+
+    def cleanup(self):
+        """Closes the connection to the database."""
+        self.connection.close()
+
+    def __del__(self):
+        # This should be deprecated -- using __del__ is unreliable for closing connections to db's;
+        # the preferred way should be for the user to use a context manager or use the `.cleanup()`
+        # method within a REST API framework.
+
+        # closes connection at end when things are being shutdown.
+        self.connection.close()
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        if not hasattr(self.connection, "info"):
+            logger.warning(
+                "Postgresql information for connection object not available. Cannot serialize persister."
+            )
+            return state
+        state["connection_params"] = {
+            "dbname": self.connection.info.dbname,
+            "user": self.connection.info.user,
+            "password": self.connection.info.password,
+            "host": self.connection.info.host,
+            "port": self.connection.info.port,
+        }
+        del state["connection"]
+        return state
+
+    def __setstate__(self, state: dict):
+        connection_params = state.pop("connection_params")
+        # we assume normal psycopg2 client.
+        self.connection = psycopg2.connect(**connection_params)
+        self.__dict__.update(state)
+
+
+if __name__ == "__main__":
+    # test the PostgreSQLPersister class
+    persister = PostgreSQLPersister.from_values(
+        "postgres", "postgres", "my_password", "localhost", 54320, table_name="burr_state"
+    )
+
+    persister.initialize()
+    persister.save("pk", "app_id", 1, "pos", state.State({"a": 1, "b": 2}), "completed")
+    print(persister.list_app_ids("pk"))
+    print(persister.load("pk", "app_id"))

--- a/burr/integrations/persisters/b_pymongo.py
+++ b/burr/integrations/persisters/b_pymongo.py
@@ -1,0 +1,176 @@
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from pymongo import MongoClient
+
+from burr.core import persistence, state
+
+logger = logging.getLogger(__name__)
+
+
+class MongoDBBasePersister(persistence.BaseStatePersister):
+    """A class used to represent a MongoDB Persister.
+
+    Example usage:
+
+    .. code-block:: python
+
+       persister = MongoDBBasePersister.from_values(uri='mongodb://user:pass@localhost:27017',
+                                                    db_name='mydatabase',
+                                                    collection_name='mystates')
+       persister.save(
+           partition_key='example_partition',
+           app_id='example_app',
+           sequence_id=1,
+           position='example_position',
+           state=state.State({'key': 'value'}),
+           status='completed'
+       )
+       loaded_state = persister.load(partition_key='example_partition', app_id='example_app', sequence_id=1)
+       print(loaded_state)
+
+    Note: this is called MongoDBBasePersister because we had to change the constructor and wanted to make
+     this change backwards compatible.
+    """
+
+    @classmethod
+    def from_config(cls, config: dict) -> "MongoDBBasePersister":
+        """Creates a new instance of the MongoDBBasePersister from a configuration dictionary."""
+        return cls.from_values(**config)
+
+    @classmethod
+    def from_values(
+        cls,
+        uri="mongodb://localhost:27017",
+        db_name="mydatabase",
+        collection_name="mystates",
+        serde_kwargs: dict = None,
+        mongo_client_kwargs: dict = None,
+    ) -> "MongoDBBasePersister":
+        """Initializes the MongoDBBasePersister class."""
+        if mongo_client_kwargs is None:
+            mongo_client_kwargs = {}
+        client = MongoClient(uri, **mongo_client_kwargs)
+        return cls(
+            client=client,
+            db_name=db_name,
+            collection_name=collection_name,
+            serde_kwargs=serde_kwargs,
+        )
+
+    def __init__(
+        self,
+        client,
+        db_name="mydatabase",
+        collection_name="mystates",
+        serde_kwargs: dict = None,
+    ):
+        """Initializes the MongoDBBasePersister class.
+
+        :param client: the mongodb client to use
+        :param db_name: the name of the database to use
+        :param collection_name: the name of the collection to use
+        :param serde_kwargs: serializer/deserializer keyword arguments to pass to the state object
+        """
+        self.client = client
+        self.db = self.client[db_name]
+        self.collection = self.db[collection_name]
+        self.serde_kwargs = serde_kwargs or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.connection.close()
+        return False
+
+    def set_serde_kwargs(self, serde_kwargs: dict):
+        """Sets the serde_kwargs for the persister."""
+        self.serde_kwargs = serde_kwargs
+
+    def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
+        """List the app ids for a given partition key."""
+        app_ids = self.collection.distinct("app_id", {"partition_key": partition_key})
+        return app_ids
+
+    def load(
+        self, partition_key: str, app_id: str, sequence_id: int = None, **kwargs
+    ) -> Optional[persistence.PersistedStateData]:
+        """Load the state data for a given partition key, app id, and sequence id."""
+        query = {"partition_key": partition_key, "app_id": app_id}
+        if sequence_id is not None:
+            query["sequence_id"] = sequence_id
+        document = self.collection.find_one(query, sort=[("sequence_id", -1)])
+        if not document:
+            return None
+        _state = state.State.deserialize(json.loads(document["state"]), **self.serde_kwargs)
+        return {
+            "partition_key": partition_key,
+            "app_id": app_id,
+            "sequence_id": document["sequence_id"],
+            "position": document["position"],
+            "state": _state,
+            "created_at": document["created_at"],
+            "status": document["status"],
+        }
+
+    def save(
+        self,
+        partition_key: str,
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: state.State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        """Save the state data to the MongoDB database."""
+        key = {"partition_key": partition_key, "app_id": app_id, "sequence_id": sequence_id}
+        if self.collection.find_one(key):
+            raise ValueError(f"partition_key:app_id:sequence_id[{key}] already exists.")
+        json_state = json.dumps(state.serialize(**self.serde_kwargs))
+        self.collection.insert_one(
+            {
+                "partition_key": partition_key,
+                "app_id": app_id,
+                "sequence_id": sequence_id,
+                "position": position,
+                "state": json_state,
+                "status": status,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+    def cleanup(self):
+        """Closes the connection to the database."""
+        self.connection.close()
+
+    def __del__(self):
+        # This should be deprecated -- using __del__ is unreliable for closing connections to db's;
+        # the preferred way should be for the user to use a context manager or use the `.cleanup()`
+        # method within a REST API framework.
+
+        self.client.close()
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["connection_params"] = {
+            "uri": self.client.address[0],
+            "port": self.client.address[1],
+            "db_name": self.db.name,
+            "collection_name": self.collection.name,
+        }
+        del state["client"]
+        del state["db"]
+        del state["collection"]
+        return state
+
+    def __setstate__(self, state: dict):
+        connection_params = state.pop("connection_params")
+        # we assume MongoClient.
+        self.client = MongoClient(connection_params["uri"], connection_params["port"])
+        self.db = self.client[connection_params["db_name"]]
+        self.collection = self.db[connection_params["collection_name"]]
+        self.__dict__.update(state)

--- a/burr/integrations/persisters/b_redis.py
+++ b/burr/integrations/persisters/b_redis.py
@@ -2,6 +2,7 @@ from burr.integrations import base
 
 try:
     import redis  # can't name module redis because this import wouldn't work.
+    import redis.asyncio as aredis
 
 except ImportError as e:
     base.require_plugin(e, "redis")
@@ -16,6 +17,14 @@ from burr.core import persistence, state
 logger = logging.getLogger(__name__)
 
 
+def add_namespace_to_partition_key(partition_key: str, namespace: Optional[str] = None) -> str:
+    """Helper function to add namespace to partition key."""
+
+    if namespace:
+        return f"{namespace}:{partition_key}"
+    return partition_key
+
+
 class RedisBasePersister(persistence.BaseStatePersister):
     """Main class for Redis persister.
 
@@ -27,6 +36,11 @@ class RedisBasePersister(persistence.BaseStatePersister):
     Note: We didn't create the right constructor for the initial implementation of the RedisPersister class,
     so this is an attempt to fix that in a backwards compatible way.
     """
+
+    @classmethod
+    def from_config(cls, config: dict) -> "RedisBasePersister":
+        """Creates a new instance of the RedisBasePersister from a configuration dictionary."""
+        return cls.from_values(**config)
 
     @classmethod
     def from_values(
@@ -63,11 +77,20 @@ class RedisBasePersister(persistence.BaseStatePersister):
         self.serde_kwargs = serde_kwargs or {}
         self.namespace = namespace if namespace else ""
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.connection.close()
+        return False
+
+    def set_serde_kwargs(self, serde_kwargs: dict):
+        """Sets the serde_kwargs for the persister."""
+        self.serde_kwargs = serde_kwargs
+
     def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
         """List the app ids for a given partition key."""
-        namespaced_partition_key = (
-            f"{self.namespace}:{partition_key}" if self.namespace else partition_key
-        )
+        namespaced_partition_key = add_namespace_to_partition_key(partition_key, self.namespace)
         app_ids = self.connection.zrevrange(namespaced_partition_key, 0, -1)
         return [app_id.decode() for app_id in app_ids]
 
@@ -84,9 +107,7 @@ class RedisBasePersister(persistence.BaseStatePersister):
         :param kwargs:
         :return: Value or None.
         """
-        namespaced_partition_key = (
-            f"{self.namespace}:{partition_key}" if self.namespace else partition_key
-        )
+        namespaced_partition_key = add_namespace_to_partition_key(partition_key, self.namespace)
         if sequence_id is None:
             sequence_id = self.connection.zscore(namespaced_partition_key, app_id)
             if sequence_id is None:
@@ -109,11 +130,9 @@ class RedisBasePersister(persistence.BaseStatePersister):
 
     def create_key(self, app_id, partition_key, sequence_id):
         """Create a key for the Redis database."""
-        if self.namespace:
-            key = f"{self.namespace}:{partition_key}:{app_id}:{sequence_id}"
-        else:
-            key = f"{partition_key}:{app_id}:{sequence_id}"
-        return key
+        return add_namespace_to_partition_key(
+            f"{partition_key}:{app_id}:{sequence_id}", self.namespace
+        )
 
     def save(
         self,
@@ -152,19 +171,22 @@ class RedisBasePersister(persistence.BaseStatePersister):
                 "created_at": datetime.now(timezone.utc).isoformat(),
             },
         )
-        namespaced_partition_key = (
-            f"{self.namespace}:{partition_key}" if self.namespace else partition_key
-        )
+        namespaced_partition_key = add_namespace_to_partition_key(partition_key, self.namespace)
         self.connection.zadd(namespaced_partition_key, {app_id: sequence_id})
 
+    def cleanup(self):
+        """Closes the connection to the database."""
+        self.connection.close()
+
     def __del__(self):
+        # This should be deprecated -- using __del__ is unreliable for closing connections to db's;
+        # the preferred way should be for the user to use a context manager or use the `.cleanup()`
+        # method within a REST API framework.
+
         self.connection.close()
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
-        if not hasattr(self.connection, "connection_pool"):
-            logger.warning("Redis connection is not serializable.")
-            return state
         state["connection_params"] = {
             "host": self.connection.connection_pool.connection_kwargs["host"],
             "port": self.connection.connection_pool.connection_kwargs["port"],
@@ -179,6 +201,163 @@ class RedisBasePersister(persistence.BaseStatePersister):
         # we assume normal redis client.
         self.connection = redis.Redis(**connection_params)
         self.__dict__.update(state)
+
+
+class AsyncRedisBasePersister(persistence.AsyncBaseStatePersister):
+    """Main class for async Redis persister.
+
+    .. warning::
+        The synchronous persister closes the connection on deletion of the class using the ``__del__`` method.
+        In an async context that is not reliable (the event loop may already be closed by the time ``__del__``
+        gets invoked). Therefore, you are responsible for closing the connection yourself (i.e. manual cleanup).
+        We suggest to use the persister either as a context manager through the ``async with`` clause or
+        using the method ``.cleanup()``.
+
+
+    This class is responsible for async persisting state data to a Redis database.
+    It inherits from the AsyncBaseStatePersister class.
+    """
+
+    @classmethod
+    def from_config(cls, config: dict) -> "AsyncRedisBasePersister":
+        """Creates a new instance of the RedisBasePersister from a configuration dictionary."""
+        return cls.from_values(**config)
+
+    @classmethod
+    def from_values(
+        cls,
+        host: str,
+        port: int,
+        db: int,
+        password: str = None,
+        serde_kwargs: dict = None,
+        redis_client_kwargs: dict = None,
+        namespace: str = None,
+    ) -> "AsyncRedisBasePersister":
+        """Creates a new instance of the AsyncRedisBasePersister from passed in values."""
+        if redis_client_kwargs is None:
+            redis_client_kwargs = {}
+        connection = aredis.Redis(
+            host=host, port=port, db=db, password=password, **redis_client_kwargs
+        )
+        return cls(connection, serde_kwargs, namespace)
+
+    def __init__(
+        self,
+        connection,
+        serde_kwargs: dict = None,
+        namespace: str = None,
+    ):
+        """Initializes the AsyncRedisPersister class.
+
+        :param connection: the redis connection object.
+        :param serde_kwargs: serialization and deserialization keyword arguments to pass to state SERDE.
+        :param namespace: The name of the project to optionally use in the key prefix.
+        """
+        self.connection = connection
+        self.serde_kwargs = serde_kwargs or {}
+        self.namespace = namespace if namespace else ""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.connection.aclose()
+        return False
+
+    def set_serde_kwargs(self, serde_kwargs: dict):
+        """Sets the serde_kwargs for the persister."""
+        self.serde_kwargs = serde_kwargs
+
+    async def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
+        """List the app ids for a given partition key."""
+        namespaced_partition_key = add_namespace_to_partition_key(partition_key, self.namespace)
+        app_ids = await self.connection.zrevrange(namespaced_partition_key, 0, -1)
+        return [app_id.decode() for app_id in app_ids]
+
+    async def load(
+        self, partition_key: str, app_id: str, sequence_id: int = None, **kwargs
+    ) -> Optional[persistence.PersistedStateData]:
+        """Load the state data for a given partition key, app id, and sequence id.
+
+        If the sequence id is not given, it will be looked up in the Redis database. If it is not found, None will be returned.
+
+        :param partition_key:
+        :param app_id:
+        :param sequence_id:
+        :param kwargs:
+        :return: Value or None.
+        """
+        namespaced_partition_key = add_namespace_to_partition_key(partition_key, self.namespace)
+        if sequence_id is None:
+            sequence_id = await self.connection.zscore(namespaced_partition_key, app_id)
+            if sequence_id is None:
+                return None
+            sequence_id = int(sequence_id)
+        key = self.create_key(app_id, partition_key, sequence_id)
+        data = await self.connection.hgetall(key)
+        if not data:
+            return None
+        _state = state.State.deserialize(json.loads(data[b"state"].decode()), **self.serde_kwargs)
+        return {
+            "partition_key": partition_key,
+            "app_id": app_id,
+            "sequence_id": sequence_id,
+            "position": data[b"position"].decode(),
+            "state": _state,
+            "created_at": data[b"created_at"].decode(),
+            "status": data[b"status"].decode(),
+        }
+
+    def create_key(self, app_id, partition_key, sequence_id):
+        """Create a key for the Redis database."""
+        return add_namespace_to_partition_key(
+            f"{partition_key}:{app_id}:{sequence_id}", self.namespace
+        )
+
+    async def save(
+        self,
+        partition_key: str,
+        app_id: str,
+        sequence_id: int,
+        position: str,
+        state: state.State,
+        status: Literal["completed", "failed"],
+        **kwargs,
+    ):
+        """Save the state data to the Redis database.
+
+        :param partition_key:
+        :param app_id:
+        :param sequence_id:
+        :param position:
+        :param state:
+        :param status:
+        :param kwargs:
+        :return:
+        """
+        key = self.create_key(app_id, partition_key, sequence_id)
+        if await self.connection.exists(key):
+            raise ValueError(f"partition_key:app_id:sequence_id[{key}] already exists.")
+        json_state = json.dumps(state.serialize(**self.serde_kwargs))
+        await self.connection.hset(
+            key,
+            mapping={
+                "partition_key": partition_key,
+                "app_id": app_id,
+                "sequence_id": sequence_id,
+                "position": position,
+                "state": json_state,
+                "status": status,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        namespaced_partition_key = add_namespace_to_partition_key(partition_key, self.namespace)
+        await self.connection.zadd(namespaced_partition_key, {app_id: sequence_id})
+
+    async def cleanup(self):
+        """Closes the connection to the database."""
+        await self.connection.aclose()
 
 
 class RedisPersister(RedisBasePersister):

--- a/burr/integrations/persisters/postgresql.py
+++ b/burr/integrations/persisters/postgresql.py
@@ -1,55 +1,30 @@
+"""This module is depricated. Please import from b_psycopg2.py."""
+
 from burr.integrations import base
+from burr.integrations.persisters.b_psycopg2 import PostgreSQLPersister as Psycopg2Persister
 
 try:
     import psycopg2
 except ImportError as e:
     base.require_plugin(e, "postgresql")
 
-import json
-import logging
-from typing import Literal, Optional
 
-from burr.core import persistence, state
+import logging
+
+from burr.core import state
 
 logger = logging.getLogger(__name__)
+logger.warning(
+    "This class is deprecated and has been moved. "
+    "Please import PostgreSQLPersister from b_psycopg2.py."
+)
 
 
-class PostgreSQLPersister(persistence.BaseStatePersister):
-    """Class for PostgreSQL persistence of state. This is a simple implementation.
+class PostgreSQLPersister(Psycopg2Persister):
+    """A class used to represent the Postgresql Persister.
 
-    To try it out locally with docker -- here's a command -- change the values as appropriate.
-
-    .. code:: bash
-
-        docker run --name local-psql \  # container name
-                   -v local_psql_data:/SOME/FILE_PATH/ \  # mounting a volume for data persistence
-                   -p 54320:5432 \  # port mapping
-                   -e POSTGRES_PASSWORD=my_password \  # superuser password
-                   -d postgres  # database name
-
-    Then you should be able to create the class like this:
-
-    .. code:: python
-
-        p = PostgreSQLPersister.from_values("postgres", "postgres", "my_password",
-                                           "localhost", 54320, table_name="burr_state")
-
-
+    This class is deprecated and has been moved to b_psycopg2.py.
     """
-
-    PARTITION_KEY_DEFAULT = ""
-
-    @classmethod
-    def from_config(cls, config: dict) -> "PostgreSQLPersister":
-        """Creates a new instance of the PostgreSQLPersister from a configuration dictionary."""
-        return cls.from_values(
-            db_name=config["db_name"],
-            user=config["user"],
-            password=config["password"],
-            host=config["host"],
-            port=config["port"],
-            table_name=config.get("table_name", "burr_state"),
-        )
 
     @classmethod
     def from_values(
@@ -73,201 +48,7 @@ class PostgreSQLPersister(persistence.BaseStatePersister):
         connection = psycopg2.connect(
             dbname=db_name, user=user, password=password, host=host, port=port
         )
-        return cls(connection, table_name)
-
-    def __init__(self, connection, table_name: str = "burr_state", serde_kwargs: dict = None):
-        """Constructor
-
-        :param connection: the connection to the PostgreSQL database.
-        :param table_name:  the table name to store things under.
-        """
-        self.table_name = table_name
-        self.connection = connection
-        self.serde_kwargs = serde_kwargs or {}
-        self._initialized = False
-
-    def set_serde_kwargs(self, serde_kwargs: dict):
-        """Sets the serde_kwargs for the persister."""
-        self.serde_kwargs = serde_kwargs
-
-    def create_table(self, table_name: str):
-        """Helper function to create the table where things are stored."""
-        cursor = self.connection.cursor()
-        cursor.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS {table_name} (
-                partition_key TEXT DEFAULT '{self.PARTITION_KEY_DEFAULT}',
-                app_id TEXT NOT NULL,
-                sequence_id INTEGER NOT NULL,
-                position TEXT NOT NULL,
-                status TEXT NOT NULL,
-                state JSONB NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (partition_key, app_id, sequence_id, position)
-            )"""
-        )
-        cursor.execute(
-            f"""
-            CREATE INDEX IF NOT EXISTS {table_name}_created_at_index ON {table_name} (created_at);
-        """
-        )
-        self.connection.commit()
-
-    def initialize(self):
-        """Creates the table"""
-        self.create_table(self.table_name)
-        self._initialized = True
-
-    def is_initialized(self) -> bool:
-        """This checks to see if the table has been created in the database or not.
-        It defaults to using the initialized field, else queries the database to see if the table exists.
-        It then sets the initialized field to True if the table exists.
-        """
-        if self._initialized:
-            return True
-        cursor = self.connection.cursor()
-        cursor.execute(
-            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
-            (self.table_name,),
-        )
-        self._initialized = cursor.fetchone()[0]
-        return self._initialized
-
-    def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
-        """Lists the app_ids for a given partition_key."""
-        cursor = self.connection.cursor()
-        cursor.execute(
-            f"SELECT DISTINCT app_id, created_at FROM {self.table_name} "
-            "WHERE partition_key = %s "
-            "ORDER BY created_at DESC",
-            (partition_key,),
-        )
-        app_ids = [row[0] for row in cursor.fetchall()]
-        return app_ids
-
-    def load(
-        self, partition_key: Optional[str], app_id: str, sequence_id: int = None, **kwargs
-    ) -> Optional[persistence.PersistedStateData]:
-        """Loads state for a given partition id.
-
-        Depending on the parameters, this will return the last thing written, the last thing written for a given app_id,
-        or a specific sequence_id for a given app_id.
-
-        :param partition_key:
-        :param app_id:
-        :param sequence_id:
-        :return:
-        """
-        if partition_key is None:
-            partition_key = self.PARTITION_KEY_DEFAULT
-        logger.debug("Loading %s, %s, %s", partition_key, app_id, sequence_id)
-        cursor = self.connection.cursor()
-        if app_id is None:
-            # get latest for all app_ids
-            cursor.execute(
-                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
-                f"WHERE partition_key = %s "
-                f"ORDER BY CREATED_AT DESC LIMIT 1",
-                (partition_key,),
-            )
-        elif sequence_id is None:
-            cursor.execute(
-                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
-                f"WHERE partition_key = %s AND app_id = %s "
-                f"ORDER BY sequence_id DESC LIMIT 1",
-                (partition_key, app_id),
-            )
-        else:
-            cursor.execute(
-                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
-                f"WHERE partition_key = %s AND app_id = %s AND sequence_id = %s ",
-                (partition_key, app_id, sequence_id),
-            )
-        row = cursor.fetchone()
-        if row is None:
-            return None
-        _state = state.State.deserialize(row[1], **self.serde_kwargs)
-        return {
-            "partition_key": partition_key,
-            "app_id": row[3],
-            "sequence_id": row[2],
-            "position": row[0],
-            "state": _state,
-            "created_at": row[4],
-            "status": row[5],
-        }
-
-    def save(
-        self,
-        partition_key: str,
-        app_id: str,
-        sequence_id: int,
-        position: str,
-        state: state.State,
-        status: Literal["completed", "failed"],
-        **kwargs,
-    ):
-        """
-        Saves the state for a given app_id, sequence_id, and position.
-
-        This method connects to the SQLite database, converts the state to a JSON string, and inserts a new record
-        into the table with the provided partition_key, app_id, sequence_id, position, and state. After the operation,
-        it commits the changes and closes the connection to the database.
-
-        :param partition_key: The partition key. This could be None, but it's up to the persistor to whether
-            that is a valid value it can handle.
-        :param app_id: The identifier for the app instance being recorded.
-        :param sequence_id: The state corresponding to a specific point in time.
-        :param position: The position in the sequence of states.
-        :param state: The state to be saved, an instance of the State class.
-        :param status: The status of this state, either "completed" or "failed". If "failed" the state is what it was
-            before the action was applied.
-        :return: None
-        """
-        logger.debug(
-            "saving %s, %s, %s, %s, %s, %s",
-            partition_key,
-            app_id,
-            sequence_id,
-            position,
-            state,
-            status,
-        )
-        cursor = self.connection.cursor()
-        json_state = json.dumps(state.serialize(**self.serde_kwargs))
-        cursor.execute(
-            f"INSERT INTO {self.table_name} (partition_key, app_id, sequence_id, position, state, status) "
-            "VALUES (%s, %s, %s, %s, %s, %s)",
-            (partition_key, app_id, sequence_id, position, json_state, status),
-        )
-        self.connection.commit()
-
-    def __del__(self):
-        # closes connection at end when things are being shutdown.
-        self.connection.close()
-
-    def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        if not hasattr(self.connection, "info"):
-            logger.warning(
-                "Postgresql information for connection object not available. Cannot serialize persister."
-            )
-            return state
-        state["connection_params"] = {
-            "dbname": self.connection.info.dbname,
-            "user": self.connection.info.user,
-            "password": self.connection.info.password,
-            "host": self.connection.info.host,
-            "port": self.connection.info.port,
-        }
-        del state["connection"]
-        return state
-
-    def __setstate__(self, state: dict):
-        connection_params = state.pop("connection_params")
-        # we assume normal psycopg2 client.
-        self.connection = psycopg2.connect(**connection_params)
-        self.__dict__.update(state)
+        return Psycopg2Persister(connection, table_name)
 
 
 if __name__ == "__main__":

--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -5,8 +5,29 @@ State Persistence
 Burr provides a set of tools to make loading and saving state easy. These are functions
 that will be used by lifecycle hooks to save and load state.
 
+We currently support the following database integrations:
+
+.. table:: Burr Implemented Persisters
+    :widths: auto
+
+    +-------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
+    | Database    | Sync                                                            | Async                                                               |
+    +=============+===========+=====================================================+===============+=====================================================+
+    | SQLite      | sqlite3   | :ref:`SQLitePersister <syncsqliteref>`              | aiosqlite     | :ref:`AsyncSQLitePersister <asyncsqliteref>`        |
+    +-------------+-----------+-----------------------------------------------------+---------------+-----------------------------------------------------+
+    | PostgreSQL  | psycopg2  | :ref:`PostgreSQLPersister <syncpostgresref>`        | asyncpg       | :ref:`AsyncPostgreSQLPersister <asyncpostgresref>`  |
+    +-------------+-----------+-----------------------------------------------------+---------------+-----------------------------------------------------+
+    | Redis       | redis     | :ref:`RedisBasePersister <syncredisref>`            | redis.asyncio | :ref:`AsyncRedisBasePersister <asyncredisref>`      |
+    +-------------+-----------+-----------------------------------------------------+---------------+-----------------------------------------------------+
+    | MongoDB     | pymongo   | :ref:`MongoDBBasePersister <syncmongoref>`          | ❌            | ❌                                                  |
+    +-------------+-----------+-----------------------------------------------------+---------------+-----------------------------------------------------+
+
+We follow the naming convention ``b_dependency-library``, where the ``b_`` is used to avoid name
+clashing with the underlying library. We chose the library name in case we implement the same database
+persister with different dependency libraries to keep the class naming convention.
+
 If you want to implement your own state persister (to bridge it with a database), you should implement
-the ``BaseStatePersister`` interface.
+the ``BaseStatePersister`` or the ``AsyncBaseStatePersister`` interface.
 
 .. autoclass:: burr.core.persistence.BaseStatePersister
    :members:
@@ -61,23 +82,30 @@ Supported Sync Implementations
 
 Currently we support the following, although we highly recommend you contribute your own! We will be adding more shortly.
 
+.. _syncsqliteref:
+
 .. autoclass:: burr.core.persistence.SQLitePersister
    :members:
 
    .. automethod:: __init__
 
+.. _syncpostgresref:
 
-.. autoclass:: burr.integrations.persisters.postgresql.PostgreSQLPersister
+.. autoclass:: burr.integrations.persisters.b_psycopg2.PostgreSQLPersister
    :members:
 
    .. automethod:: __init__
+
+.. _syncredisref:
 
 .. autoclass:: burr.integrations.persisters.b_redis.RedisBasePersister
    :members:
 
    .. automethod:: __init__
 
-.. autoclass:: burr.integrations.persisters.b_mongodb.MongoDBBasePersister
+.. _syncmongoref:
+
+.. autoclass:: burr.integrations.persisters.b_pymongo.MongoDBBasePersister
    :members:
 
    .. automethod:: __init__
@@ -90,19 +118,25 @@ although it uses different mechanisms to save state (as it tracks more than just
 Supported Async Implementations
 ================================
 
+.. _asyncpersistersref:
+
 Currently we support the following, although we highly recommend you contribute your own! We will be adding more shortly.
 
-.. _asyncpersistersref:
+.. _asyncsqliteref:
 
 .. autoclass:: burr.integrations.persisters.b_aiosqlite.AsyncSQLitePersister
    :members:
 
    .. automethod:: __init__
 
-.. autoclass:: burr.integrations.persisters.postgresql.AsyncPostgreSQLPersister
+.. _asyncpostgresref:
+
+.. autoclass:: burr.integrations.persisters.b_asyncpg.AsyncPostgreSQLPersister
    :members:
 
    .. automethod:: __init__
+
+.. _asyncredisref:
 
 .. autoclass:: burr.integrations.persisters.b_redis.AsyncRedisBasePersister
    :members:

--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -98,3 +98,8 @@ Currently we support the following, although we highly recommend you contribute 
    :members:
 
    .. automethod:: __init__
+
+.. autoclass:: burr.integrations.persisters.postgresql.AsyncPostgreSQLPersister
+   :members:
+
+   .. automethod:: __init__

--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -103,3 +103,8 @@ Currently we support the following, although we highly recommend you contribute 
    :members:
 
    .. automethod:: __init__
+
+.. autoclass:: burr.integrations.persisters.b_redis.AsyncRedisBasePersister
+   :members:
+
+   .. automethod:: __init__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ aiosqlite = [
 ]
 
 postgresql = [
-  "psycopg2-binary"
+  "psycopg2-binary",
+  "asyncpg"
 ]
 
 redis = [
@@ -62,6 +63,7 @@ tests = [
   "langchain_community",
   "pandas",
   "psycopg2",
+  "asyncpg",
   "pydantic[email]",
   "pyarrow",
   "redis",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,20 @@ aiosqlite = [
   "aiosqlite"
 ]
 
-postgresql = [
-  "psycopg2-binary",
+asyncpg = [
   "asyncpg"
+]
+
+postgresql = [
+  "psycopg2-binary"
+] # leaving it here for backwards compatibility
+
+psycopg2 = [
+  "psycopg2-binary"
+]
+
+pymongo = [
+  "pymongo"
 ]
 
 redis = [
@@ -57,17 +68,17 @@ tests = [
   "pytest",
   "pytest-asyncio",
   "burr[hamilton]",
-  "pymongo",
   "burr[hamilton]",
   "langchain_core",
   "langchain_community",
   "pandas",
-  "psycopg2",
-  "asyncpg",
   "pydantic[email]",
   "pyarrow",
-  "redis",
-  "aiosqlite",
+  "burr[aiosqlite]",
+  "burr[asyncpg]",
+  "burr[psycopg2]",
+  "burr[pymongo]",
+  "burr[redis]",
   "burr[opentelemetry]",
   "burr[haystack]",
   "burr[ray]"
@@ -81,10 +92,12 @@ documentation = [
   "furo",
   "sphinx-sitemap",
   "sphinx-toolbox",
-  "psycopg2-binary",
-  "redis",
-  "ray",
-  "aiosqlite",
+  "burr[aiosqlite]",
+  "burr[asyncpg]",
+  "burr[psycopg2]",
+  "burr[pymongo]",
+  "burr[redis]",
+  "burr[ray]",
   "sphinxcontrib-googleanalytics"
 ]
 
@@ -180,8 +193,9 @@ opentelemetry = [
 ]
 
 ray = [
-  "ray"
+  "ray[default]"
 ]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -13,15 +13,19 @@ from burr.core.persistence import InMemoryPersister, SQLLitePersister
 def persistence(request):
     which = request.param["which"]
     if which == "sqlite":
-        return SQLLitePersister(db_path=":memory:", table_name="test_table")
+        persister = SQLLitePersister(db_path=":memory:", table_name="test_table")
+        yield persister
+        persister.cleanup()
     elif which == "memory":
-        return InMemoryPersister()
+        yield InMemoryPersister()
     # return SQLLitePersister(db_path=":memory:", table_name="test_table")
 
 
 @pytest.fixture()
 def initializing_persistence():
-    return SQLLitePersister(db_path=":memory:", table_name="test_table")
+    persister = SQLLitePersister(db_path=":memory:", table_name="test_table")
+    yield persister
+    persister.cleanup()
 
 
 def test_persistence_initialization_creates_table(initializing_persistence):
@@ -69,6 +73,8 @@ def test_sqlite_persistence_is_initialized_true_new_connection(tmp_path):
     assert p.is_initialized()
     p2 = SQLLitePersister(db_path=db_path, table_name="test_table")
     assert p2.is_initialized()
+    p.cleanup()
+    p2.cleanup()
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/persisters/test_b_aiosqlite.py
+++ b/tests/integrations/persisters/test_b_aiosqlite.py
@@ -16,7 +16,7 @@ class AsyncSQLiteContextManager:
         return self.client
 
     async def __aexit__(self, exc_type, exc, tb):
-        await self.client.close()
+        await self.client.cleanup()
 
 
 async def test_copy_persister(async_persistence: AsyncSQLitePersister):

--- a/tests/integrations/persisters/test_b_mongodb.py
+++ b/tests/integrations/persisters/test_b_mongodb.py
@@ -4,7 +4,8 @@ import pickle
 import pytest
 
 from burr.core import state
-from burr.integrations.persisters.b_mongodb import MongoDBBasePersister, MongoDBPersister
+from burr.integrations.persisters.b_mongodb import MongoDBPersister
+from burr.integrations.persisters.b_pymongo import MongoDBBasePersister
 
 if not os.environ.get("BURR_CI_INTEGRATION_TESTS") == "true":
     pytest.skip("Skipping integration tests", allow_module_level=True)

--- a/tests/integrations/persisters/test_b_redis.py
+++ b/tests/integrations/persisters/test_b_redis.py
@@ -4,7 +4,11 @@ import pickle
 import pytest
 
 from burr.core import state
-from burr.integrations.persisters.b_redis import RedisBasePersister, RedisPersister
+from burr.integrations.persisters.b_redis import (
+    AsyncRedisBasePersister,
+    RedisBasePersister,
+    RedisPersister,
+)
 
 if not os.environ.get("BURR_CI_INTEGRATION_TESTS") == "true":
     pytest.skip("Skipping integration tests", allow_module_level=True)
@@ -14,14 +18,14 @@ if not os.environ.get("BURR_CI_INTEGRATION_TESTS") == "true":
 def redis_persister():
     persister = RedisBasePersister.from_values(host="localhost", port=6379, db=0)
     yield persister
-    persister.connection.close()
+    persister.cleanup()
 
 
 @pytest.fixture
 def redis_persister_with_ns():
     persister = RedisBasePersister.from_values(host="localhost", port=6379, db=0, namespace="test")
     yield persister
-    persister.connection.close()
+    persister.cleanup()
 
 
 def test_save_and_load_state(redis_persister):
@@ -89,3 +93,65 @@ def test_serialization_with_pickle(redis_persister_with_ns):
     data = deserialized_persister.load("pk", "app_id_serde", 1)
 
     assert data["state"].get_all() == {"a": 1, "b": 2}
+
+
+@pytest.fixture
+async def async_redis_persister():
+    persister = AsyncRedisBasePersister.from_values(host="localhost", port=6379, db=1)
+    yield persister
+    await persister.cleanup()
+
+
+@pytest.fixture
+async def async_redis_persister_with_ns():
+    persister = AsyncRedisBasePersister.from_values(
+        host="localhost", port=6379, db=1, namespace="test_async"
+    )
+    yield persister
+    await persister.cleanup()
+
+
+async def test_async_save_and_load_state(async_redis_persister):
+    await async_redis_persister.save(
+        "pk", "app_id", 1, "pos", state.State({"a": 1, "b": 2}), "completed"
+    )
+    data = await async_redis_persister.load("pk", "app_id", 1)
+    assert data["state"].get_all() == {"a": 1, "b": 2}
+
+
+async def test_async_list_app_ids(async_redis_persister):
+    await async_redis_persister.save("pk", "app_id1", 1, "pos1", state.State({"a": 1}), "completed")
+    await async_redis_persister.save("pk", "app_id2", 2, "pos2", state.State({"b": 2}), "completed")
+    app_ids = await async_redis_persister.list_app_ids("pk")
+    assert "app_id1" in app_ids
+    assert "app_id2" in app_ids
+
+
+async def test_async_load_nonexistent_key(async_redis_persister):
+    state_data = await async_redis_persister.load("pk", "nonexistent_key")
+    assert state_data is None
+
+
+async def test_async_save_and_load_state_ns(async_redis_persister_with_ns):
+    await async_redis_persister_with_ns.save(
+        "pk", "app_id", 1, "pos", state.State({"a": 1, "b": 2}), "completed"
+    )
+    data = await async_redis_persister_with_ns.load("pk", "app_id", 1)
+    assert data["state"].get_all() == {"a": 1, "b": 2}
+
+
+async def test_async_list_app_ids_with_ns(async_redis_persister_with_ns):
+    await async_redis_persister_with_ns.save(
+        "pk", "app_id1", 1, "pos1", state.State({"a": 1}), "completed"
+    )
+    await async_redis_persister_with_ns.save(
+        "pk", "app_id2", 2, "pos2", state.State({"b": 2}), "completed"
+    )
+    app_ids = await async_redis_persister_with_ns.list_app_ids("pk")
+    assert "app_id1" in app_ids
+    assert "app_id2" in app_ids
+
+
+async def test_async_load_nonexistent_key_with_ns(async_redis_persister_with_ns):
+    state_data = await async_redis_persister_with_ns.load("pk", "nonexistent_key")
+    assert state_data is None


### PR DESCRIPTION
Adding async support for Postgres and Redis state persisters. This expands on #488 and addresses #484 when using Postgres or Redis.

## Changes
- Potgres state persisted integrates commands using `asyncpg`.
- Redis supports async via `redis.asyncio`

## How I tested this
- unit test

## Notes
- For Postgres: `asyncpg` uses a coroutine to open/close the connection. In this case pickling / unpickling the state needs a workaround (not yet implemented) since `__getstate__` and `__setstate__` do not have async support.
- Redis pickling/unpickling is straightforward (and implemented) since the connection to the db is sync.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add asynchronous support for Redis and PostgreSQL state persisters using `redis.asyncio` and `asyncpg`.
> 
>   - **Async Support**:
>     - Added `AsyncRedisBasePersister` using `redis.asyncio` for async Redis operations in `b_redis.py`.
>     - Added `AsyncPostgreSQLPersister` using `asyncpg` for async PostgreSQL operations in `postgresql.py`.
>   - **Testing**:
>     - Added async tests in `test_b_redis.py` for `AsyncRedisBasePersister`.
>     - Added async tests in `test_postgresql.py` for `AsyncPostgreSQLPersister`.
>   - **Documentation**:
>     - Updated `persister.rst` to include `AsyncRedisBasePersister` and `AsyncPostgreSQLPersister`.
>   - **Dependencies**:
>     - Added `asyncpg` to `pyproject.toml` under `postgresql` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 304eb21ce74b37b5a4b558a527e210143199b600. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->