### PR TITLE
Fixes state writes with private variables

### DIFF
--- a/docs/concepts/state.rst
+++ b/docs/concepts/state.rst
@@ -27,6 +27,11 @@ State manipulation is done through calling methods on the ``State`` class. The m
 
     The ``State`` object can only be treated immutably! Calling ``state.update(foo=bar)`` will do nothing if you don't use the value returned by the call.
 
+.. warning::
+
+    State contains a set of "private" variables that start with `__`. -- E.G. `__SEQUENCE_ID`. These are internal to Burr, used by the application to track state.
+    Any modifications to them outside of the framework is considered undefined behavior -- it could be dropped, or error out (we reserve the right to alter this later).
+
 The read operations extend from those in the `Mapping <https://docs.python.org/3/library/collections.abc.html#collections.abc.Mapping>`_
 interface, but there are a few extra:
 


### PR DESCRIPTION
This drops private variables when written by an action. Note we do *not* add tests for this as it is undefined behavior -- we may error out later on.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `_state_update` in `application.py` now drops private variables when written by an action, with a warning added in `state.rst` about undefined behavior.
> 
>   - **Behavior**:
>     - `_state_update` in `application.py` now drops private variables (keys starting with `__`) when written by an action.
>     - Modifying private variables is considered undefined behavior and may result in errors in the future.
>   - **Documentation**:
>     - Added warning in `state.rst` about undefined behavior when modifying private variables starting with `__`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 00f17f4f36a60d01ed8fee7bc73f3d966bea4b4a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->