### PR TITLE
Adds action tagging

### DIFF
--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -172,6 +172,7 @@ def pydantic_action(
     writes: List[str],
     state_input_type: Optional[Type[pydantic.BaseModel]] = None,
     state_output_type: Optional[Type[pydantic.BaseModel]] = None,
+    tags: Optional[List[str]] = None,
 ) -> Callable[[PydanticActionFunction], PydanticActionFunction]:
     """See docstring for @action.pydantic"""
 
@@ -234,6 +235,7 @@ def pydantic_action(
                     output_type=SubsetOutputType,
                     intermediate_result_type=dict,
                 ),
+                tags=tags,
             ),
         )
         setattr(fn, "bind", types.MethodType(bind, fn))
@@ -290,6 +292,7 @@ def pydantic_streaming_action(
     state_input_type: Type[pydantic.BaseModel],
     state_output_type: Type[pydantic.BaseModel],
     stream_type: PartialType,
+    tags: Optional[List[str]] = None,
 ) -> Callable[[PydanticStreamingActionFunction], PydanticStreamingActionFunction]:
     """See docstring for @streaming_action.pydantic"""
 
@@ -353,6 +356,7 @@ def pydantic_streaming_action(
                     output_type=SubsetOutputType,
                     intermediate_result_type=stream_type_processed,
                 ),
+                tags=tags,
             ),
         )
         setattr(fn, "bind", types.MethodType(bind, fn))

--- a/docs/concepts/actions.rst
+++ b/docs/concepts/actions.rst
@@ -284,3 +284,28 @@ We need to pass in `client` and `prompt` somehow. Here are the ways to do that:
 
 For instance, say you have a chatbot. The first step will likely declare the ``input`` parameter ``prompt`` --
 it will take that, process it, and put the result in state. The subsequent steps will read the result of that from state.
+
+---------------
+Tagging Actions
+---------------
+
+You can tag actions with a list of strings -- this effectively functions as a "alias" for the action,
+so that a single alias can refer to multiple actions. This allows you to refer to a set of actions
+that have similar capabilities as one, using a variety of :ref:`application <applications>` APIs.
+
+.. code-block:: python
+
+    @action(reads=["..."], writes=["..."], tags=["response_to_display"])
+    def text_response(state: State, client: Client, prompt: str) -> State:
+        """client & `prompt` here are something we need to pass in."""
+        context = client.get_data(state["..."])
+        result = llm_call(prompt, context) # some LLM call...
+        return state.update(**result)
+
+This can be referred to either as the name of the action within the application, and/or as the tag
+``response_to_display`` -- referred to as ``@tag:response_to_display`` in the ``halt_after`` or ``halt_before`` parameters
+of :py:func:`Application.run <burr.core.application.Application.run>`, :py:func:`Application.iterate <burr.core.application.Application.iterate>`, etc.
+APIs.
+
+In all function-based APIs, you can pass in a list of tags with the ``tags`` parameter.
+In class-based APIs, you can set the ``tags`` property.

--- a/tests/core/test_action.py
+++ b/tests/core/test_action.py
@@ -68,6 +68,10 @@ class BasicAction(Action):
     def update(self, result: dict, state: State) -> State:
         return state.update(**result)
 
+    @property
+    def tags(self) -> list[str]:
+        return ["tag1", "tag2"]
+
 
 def test_with_name():
     action = BasicAction()
@@ -76,6 +80,7 @@ def test_with_name():
     assert with_name.name == "my_action"  # Name set on copy
     assert with_name.reads == action.reads
     assert with_name.writes == action.writes
+    assert with_name.tags == action.tags
 
 
 def test_condition():
@@ -230,7 +235,7 @@ def test_input():
 
 
 def test_function_based_action():
-    @action(reads=["input_variable"], writes=["output_variable"])
+    @action(reads=["input_variable"], writes=["output_variable"], tags=["tag1", "tag2"])
     def my_action(state: State) -> Tuple[dict, State]:
         return {"output_variable": state["input_variable"]}, state.update(
             output_variable=state["input_variable"]
@@ -241,13 +246,14 @@ def test_function_based_action():
     assert fn_based_action.name == "my_action"
     assert fn_based_action.reads == ["input_variable"]
     assert fn_based_action.writes == ["output_variable"]
+    assert fn_based_action.tags == ["tag1", "tag2"]
     result, state = fn_based_action.run_and_update(State({"input_variable": "foo"}))
     assert result == {"output_variable": "foo"}
     assert state.get_all() == {"input_variable": "foo", "output_variable": "foo"}
 
 
 def test_function_based_action_with_inputs():
-    @action(reads=["input_variable"], writes=["output_variable"])
+    @action(reads=["input_variable"], writes=["output_variable"], tags=["tag1", "tag2"])
     def my_action(state: State, bound_input: int, unbound_input: int) -> Tuple[dict, State]:
         res = state["input_variable"] + bound_input + unbound_input
         return {"output_variable": res}, state.update(output_variable=res)
@@ -256,6 +262,7 @@ def test_function_based_action_with_inputs():
         SingleStepAction, create_action(my_action.bind(bound_input=10), name="my_action")
     )
     assert fn_based_action.inputs == (["unbound_input"], [])
+    assert fn_based_action.tags == ["tag1", "tag2"]
     result, state = fn_based_action.run_and_update(State({"input_variable": 1}), unbound_input=100)
     assert state.get_all() == {"input_variable": 1, "output_variable": 111}
     assert result == {"output_variable": 111}
@@ -328,7 +335,7 @@ def test_function_based_action_with_defaults_unbound():
 
 
 async def test_function_based_action_async():
-    @action(reads=["input_variable"], writes=["output_variable"])
+    @action(reads=["input_variable"], writes=["output_variable"], tags=["tag1", "tag2"])
     async def my_action(state: State) -> Tuple[dict, State]:
         await asyncio.sleep(0.01)
         return {"output_variable": state["input_variable"]}, state.update(
@@ -341,6 +348,7 @@ async def test_function_based_action_async():
     assert fn_based_action.name == "my_action"
     assert fn_based_action.reads == ["input_variable"]
     assert fn_based_action.writes == ["output_variable"]
+    assert fn_based_action.tags == ["tag1", "tag2"]
     result, state = await fn_based_action.run_and_update(State({"input_variable": "foo"}))
     assert result == {"output_variable": "foo"}
     assert state.get_all() == {"input_variable": "foo", "output_variable": "foo"}
@@ -391,10 +399,11 @@ def test_create_action_class_api():
     assert created_action.name == "my_action"
     assert created_action.reads == raw_action.reads
     assert created_action.writes == raw_action.writes
+    assert created_action.tags == raw_action.tags
 
 
 def test_create_action_fn_api():
-    @action(reads=["input_variable"], writes=["output_variable"])
+    @action(reads=["input_variable"], writes=["output_variable"], tags=["tag1", "tag2"])
     def test_action(state: State) -> Tuple[dict, State]:
         result = {"output_variable": state["input_variable"]}
         return result, state.update(output_variable=result["output_variable"])
@@ -404,6 +413,7 @@ def test_create_action_fn_api():
     assert created_action.reads == ["input_variable"]
     assert created_action.writes == ["output_variable"]
     assert created_action.single_step
+    assert created_action.tags == ["tag1", "tag2"]
     result, state = created_action.run_and_update(State({"input_variable": "foo"}))
     assert result == {"output_variable": "foo"}
     assert state.get_all() == {"input_variable": "foo", "output_variable": "foo"}
@@ -435,7 +445,7 @@ def test_create_action_fn_api_with_bind():
 
 
 def test_create_action_streaming_fn_api_with_bind():
-    @streaming_action(reads=["input_variable"], writes=["output_variable"])
+    @streaming_action(reads=["input_variable"], writes=["output_variable"], tags=["tag1", "tag2"])
     def test_action(
         state: State, prefix: str
     ) -> Generator[Tuple[dict, Optional[State]], None, None]:
@@ -452,6 +462,7 @@ def test_create_action_streaming_fn_api_with_bind():
     assert created_action.name == "my_action"
     assert created_action.reads == ["input_variable"]
     assert created_action.writes == ["output_variable"]
+    assert created_action.tags == ["tag1", "tag2"]
     assert created_action.single_step
     gen = created_action.stream_run_and_update(State({"input_variable": "foo"}))
     out = [item for item in gen]
@@ -463,7 +474,7 @@ def test_create_action_streaming_fn_api_with_bind():
 
 
 async def test_create_action_streaming_fn_api_with_bind_async():
-    @streaming_action(reads=["input_variable"], writes=["output_variable"])
+    @streaming_action(reads=["input_variable"], writes=["output_variable"], tags=["tag1", "tag2"])
     async def test_action(
         state: State, prefix: str
     ) -> AsyncGenerator[Tuple[dict, Optional[State]], None]:
@@ -483,6 +494,7 @@ async def test_create_action_streaming_fn_api_with_bind_async():
     assert created_action.reads == ["input_variable"]
     assert created_action.writes == ["output_variable"]
     assert created_action.single_step
+    assert created_action.tags == ["tag1", "tag2"]
     gen = created_action.stream_run_and_update(State({"input_variable": "foo"}))
     out = [item async for item in gen]
     final_result, state = out[-1]


### PR DESCRIPTION
This enables us to use tags as aliases for actions. We may add future tags (E.G. __requires_inputs), but for now this is all done on behalf of the user. The idea is to have a very simple polymorphic interface -- we can (for example) say all nodes tagged with "text_return" fullfill the same role (displaying markdown for the user).

See #468 for more details.

[Short description explaining the high-level reason for the pull request]

## Changes

- [x] Implements tagging interface
- [x] Adds unit/integration tests
- [x] Docs
    - [x] ensure docstrings
    - [x] concepts/whatnot
- [ ] E2E test (at least one)

## How I tested this
Tests + manual.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces action tagging to group actions by aliases, updating core classes, tests, and documentation.
> 
>   - **Behavior**:
>     - Introduces action tagging, allowing actions to be tagged with aliases for grouping and identification.
>     - Updates `Application` class to process control flow parameters with tags in `_process_control_flow_params()`.
>     - Supports tags in `halt_before` and `halt_after` parameters in `Application` methods.
>   - **Graph**:
>     - Adds `_create_action_tag_map()` to map tags to actions in `Graph`.
>     - Implements `get_actions_by_tag()` to retrieve actions by tag.
>   - **Pydantic Integration**:
>     - Adds `tags` parameter to `pydantic_action()` and `pydantic_streaming_action()`.
>   - **Tests**:
>     - Adds tests for action tagging in `test_action.py`, `test_application.py`, and `test_graph.py`.
>   - **Documentation**:
>     - Updates `actions.rst` to include information on action tagging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 4123a9e7a78d0baa84847b98972d03a8632c0cda. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->