### PR TITLE
Exposes current action name through action context

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -556,6 +556,7 @@ class ApplicationContext(AbstractContextManager, ApplicationIdentifiers):
         def my_action(state: State, __context: ApplicationContext) -> State:
             app_id = __context.app_id
             partition_key = __context.partition_key
+            current_action_name = __context.action_name  # Access the current action name
             ...
 
     """
@@ -564,6 +565,7 @@ class ApplicationContext(AbstractContextManager, ApplicationIdentifiers):
     parallel_executor_factory: Callable[[], Executor]
     state_initializer: Optional[BaseStateLoader]
     state_persister: Optional[BaseStateSaver]
+    action_name: Optional[str]  # Store just the action name
 
     @staticmethod
     def get() -> Optional["ApplicationContext"]:
@@ -865,6 +867,7 @@ class Application(Generic[ApplicationStateType]):
             parallel_executor_factory=self._parallel_executor_factory,
             state_initializer=self._state_initializer,
             state_persister=self._state_persister,
+            action_name=action.name if action else None,  # Pass just the action name
         )
 
     def _step(

--- a/docs/concepts/actions.rst
+++ b/docs/concepts/actions.rst
@@ -110,7 +110,7 @@ Will require the inputs to be passed in at runtime. See below for how to do that
 
 This means that the application does not *need* the inputs to be set.
 
-Note: to access ``app_id`` and ``partition_key`` in your running application, you can have the :py:class:`ApplicationContext <burr.core.application.ApplicationContext>`
+Note: to access application-level metadata such as ``app_id``, ``partition_key``, ``sequence_id``, and ``action_name`` in your running application, you can have the :py:class:`ApplicationContext <burr.core.application.ApplicationContext>`
 injected into your Burr Actions. This is done by adding ``__context`` to the action signature:
 
 .. code-block:: python
@@ -121,6 +121,8 @@ injected into your Burr Actions. This is done by adding ``__context`` to the act
     def my_action(state: State, __context: ApplicationContext) -> State:
         app_id = __context.app_id
         partition_key = __context.partition_key
+        action_name = __context.action_name
+        sequence_id = __context.sequence_id
         ...
 
 

--- a/docs/concepts/state-persistence.rst
+++ b/docs/concepts/state-persistence.rst
@@ -43,7 +43,7 @@ Note that ``partition_key`` can be `None` if this is not relevant. A UUID is alw
 
 You set these values using the :py:meth:`with_identifiers() <burr.core.application.ApplicationBuilder.with_identifiers>` method.
 
-Note: to access ``app_id`` and ``partition_key`` in your running application, you can have the :py:class:`ApplicationContext <burr.core.application.ApplicationContext>`
+Note: to access application-level metadata such as ``app_id``, ``partition_key``, ``sequence_id``, and ``action_name`` in your running application, you can have the :py:class:`ApplicationContext <burr.core.application.ApplicationContext>`
 injected into your Burr Actions. This is done by adding ``__context`` to the action signature:
 
 .. code-block:: python
@@ -54,6 +54,8 @@ injected into your Burr Actions. This is done by adding ``__context`` to the act
     def my_action(state: State, __context: ApplicationContext) -> State:
         app_id = __context.app_id
         partition_key = __context.partition_key
+        action_name = __context.action_name
+        sequence_id = __context.sequence_id
         ...
 
 

--- a/tests/core/test_application.py
+++ b/tests/core/test_application.py
@@ -1353,6 +1353,7 @@ def test_app_step_context():
         assert __context.sequence_id == 0
         assert __context.partition_key == PARTITION_KEY
         assert __context.app_id == APP_ID
+        assert __context.action_name == "test_action"
         return state
 
     app = (
@@ -1379,6 +1380,7 @@ async def test_app_astep_context():
         assert __context.sequence_id == 0
         assert __context.partition_key == PARTITION_KEY
         assert __context.app_id == APP_ID
+        assert __context.action_name == "test_action"
         return state
 
     app = (

--- a/tests/core/test_parallelism.py
+++ b/tests/core/test_parallelism.py
@@ -1201,6 +1201,7 @@ def test_map_actions_and_states_uses_same_persister_as_loader():
             state_persister=persister,
             state_initializer=persister,
             parallel_executor_factory=lambda: concurrent.futures.ThreadPoolExecutor(),
+            action_name=action.name,
         ),
         inputs={},
     )


### PR DESCRIPTION
This allows you to get the current action name along with other application-level metadata (sequence ID, partition_key, etc...)

See #501 for details

## Changes
- added `.action_name` to ApplicationContext

## How I tested this
- unit tests

## Notes
- decided to add action name rather than action to limit API

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `action_name` to `ApplicationContext` to expose the current action name, with updates to documentation and tests.
> 
>   - **Behavior**:
>     - Adds `action_name` attribute to `ApplicationContext` in `application.py` to expose the current action name.
>     - Updates `_context_factory()` in `application.py` to set `action_name`.
>   - **Documentation**:
>     - Updates `actions.rst` and `state-persistence.rst` to include `action_name` in examples of accessing application-level metadata.
>   - **Tests**:
>     - Adds assertions for `action_name` in `test_application.py` to verify the correct action name is set in the context.
>     - Updates `test_parallelism.py` to ensure `action_name` is correctly handled in parallel execution contexts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 929ad84e3096cb75d0339b7c1c4d6cf913c6dbe7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->