### PR TITLE
Add persister best_practices docs

### DIFF
--- a/docs/reference/persister.rst
+++ b/docs/reference/persister.rst
@@ -2,6 +2,8 @@
 State Persistence
 =================
 
+.. _persistersref:
+
 Burr provides a set of tools to make loading and saving state easy. These are functions
 that will be used by lifecycle hooks to save and load state.
 
@@ -77,8 +79,6 @@ Internally, this interface combines the following two interfaces:
 
 Supported Sync Implementations
 ================================
-
-.. _persistersref:
 
 Currently we support the following, although we highly recommend you contribute your own! We will be adding more shortly.
 


### PR DESCRIPTION
Expanding the docs to document naming conventions and intended persisted usage (i.e. as context manager or using manual cleanup via `.cleanup()`)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add documentation on persister best practices, including naming conventions and usage, in `state-persistence.rst`.
> 
>   - **Documentation**:
>     - Adds section on persister usage best practices in `state-persistence.rst`, including naming conventions and usage as context managers or with `.cleanup()`.
>     - Updates example code in `state-persistence.rst` to use `SQLLitePersister.from_values`.
>   - **References**:
>     - Moves `persistersref` label in `persister.rst` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for ed0bbeef2baa33d071f80e0e15ed616baa67f0b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->