### PR TITLE
Change load and save methods on MongoDBPersister to show partition_key argument as optional

### DIFF
--- a/burr/integrations/persisters/b_pymongo.py
+++ b/burr/integrations/persisters/b_pymongo.py
@@ -96,7 +96,7 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
         return app_ids
 
     def load(
-        self, partition_key: str, app_id: str, sequence_id: int = None, **kwargs
+        self, partition_key: Optional[str], app_id: str, sequence_id: int = None, **kwargs
     ) -> Optional[persistence.PersistedStateData]:
         """Load the state data for a given partition key, app id, and sequence id."""
         query = {"partition_key": partition_key, "app_id": app_id}
@@ -118,7 +118,7 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
 
     def save(
         self,
-        partition_key: str,
+        partition_key: Optional[str],
         app_id: str,
         sequence_id: int,
         position: str,

--- a/burr/integrations/persisters/b_pymongo.py
+++ b/burr/integrations/persisters/b_pymongo.py
@@ -98,7 +98,19 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
     def load(
         self, partition_key: Optional[str], app_id: str, sequence_id: int = None, **kwargs
     ) -> Optional[persistence.PersistedStateData]:
-        """Load the state data for a given partition key, app id, and sequence id."""
+        """Loads the state data for a given partition key, app_id, and sequence_id.
+
+        This method retrieves the most recent state data for the specified (partition_key, app_id) combination.
+        If a sequence ID is provided, it will attempt to fetch the specific state at that sequence.
+
+        :param partition_key: The partition key. Defaults to `None`. **Note:** The partition key defaults to `None`. If a partition key was used during saving, it must be provided 
+        consistently during retrieval, or no results will be returned.
+        :param app_id: Application UID to read from.
+        :param sequence_id: (Optional) The sequence ID to retrieve a specific state. If not provided, 
+            the latest state is returned.
+
+        :returns: The state data if found, otherwise None.
+        """
         query = {"partition_key": partition_key, "app_id": app_id}
         if sequence_id is not None:
             query["sequence_id"] = sequence_id
@@ -126,7 +138,19 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
         status: Literal["completed", "failed"],
         **kwargs,
     ):
-        """Save the state data to the MongoDB database."""
+        """Save the state data to the MongoDB database.
+        
+        :param partition_key: the partition key. Note this could be None, but it's up to the persistor to whether
+        that is a valid value it can handle. If a partition key was used during saving, it must be provided 
+        consistently during retrieval, or no results will be returned.
+        :param app_id: Application UID to write with.
+        :param sequence_id: Sequence ID of the last executed step.
+        :param position: The action name that was implemented.
+        :param state: The current state of the application.
+        :param status: The status of this state, either "completed" or "failed". If "failed", the state is what it was
+            before the action was applied.
+        :return:
+        """
         key = {"partition_key": partition_key, "app_id": app_id, "sequence_id": sequence_id}
         if self.collection.find_one(key):
             raise ValueError(f"partition_key:app_id:sequence_id[{key}] already exists.")

--- a/burr/integrations/persisters/b_pymongo.py
+++ b/burr/integrations/persisters/b_pymongo.py
@@ -103,10 +103,10 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
         This method retrieves the most recent state data for the specified (partition_key, app_id) combination.
         If a sequence ID is provided, it will attempt to fetch the specific state at that sequence.
 
-        :param partition_key: The partition key. Defaults to `None`. **Note:** The partition key defaults to `None`. If a partition key was used during saving, it must be provided 
+        :param partition_key: The partition key. Defaults to `None`. **Note:** The partition key defaults to `None`. If a partition key was used during saving, it must be provided
         consistently during retrieval, or no results will be returned.
         :param app_id: Application UID to read from.
-        :param sequence_id: (Optional) The sequence ID to retrieve a specific state. If not provided, 
+        :param sequence_id: (Optional) The sequence ID to retrieve a specific state. If not provided,
             the latest state is returned.
 
         :returns: The state data if found, otherwise None.
@@ -139,9 +139,9 @@ class MongoDBBasePersister(persistence.BaseStatePersister):
         **kwargs,
     ):
         """Save the state data to the MongoDB database.
-        
+
         :param partition_key: the partition key. Note this could be None, but it's up to the persistor to whether
-        that is a valid value it can handle. If a partition key was used during saving, it must be provided 
+        that is a valid value it can handle. If a partition key was used during saving, it must be provided
         consistently during retrieval, or no results will be returned.
         :param app_id: Application UID to write with.
         :param sequence_id: Sequence ID of the last executed step.

--- a/tests/integrations/persisters/test_b_mongodb.py
+++ b/tests/integrations/persisters/test_b_mongodb.py
@@ -66,3 +66,16 @@ def test_serialization_with_pickle(mongodb_persister):
     data = deserialized_persister.load("pk", "app_id_serde", 1)
 
     assert data["state"].get_all() == {"a": 1, "b": 2}
+
+def test_partition_key_is_optional(mongodb_persister):
+    # 1. Save and load with partition key = None
+    mongodb_persister.save(None, "app_id_none", 1, "pos1", state.State({"foo": "bar"}), "in_progress")
+    loaded_data = mongodb_persister.load(None, "app_id_none", 1)
+    assert loaded_data is not None
+    assert loaded_data["state"].get_all() == {"foo": "bar"}
+
+    # 2. Save and load again (different key/index) with partition key = None
+    mongodb_persister.save(None, "app_id_none2", 2, "pos2", state.State({"hello": "world"}), "completed")
+    loaded_data2 = mongodb_persister.load(None, "app_id_none2", 2)
+    assert loaded_data2 is not None
+    assert loaded_data2["state"].get_all() == {"hello": "world"}

--- a/tests/integrations/persisters/test_b_mongodb.py
+++ b/tests/integrations/persisters/test_b_mongodb.py
@@ -67,15 +67,20 @@ def test_serialization_with_pickle(mongodb_persister):
 
     assert data["state"].get_all() == {"a": 1, "b": 2}
 
+
 def test_partition_key_is_optional(mongodb_persister):
     # 1. Save and load with partition key = None
-    mongodb_persister.save(None, "app_id_none", 1, "pos1", state.State({"foo": "bar"}), "in_progress")
+    mongodb_persister.save(
+        None, "app_id_none", 1, "pos1", state.State({"foo": "bar"}), "in_progress"
+    )
     loaded_data = mongodb_persister.load(None, "app_id_none", 1)
     assert loaded_data is not None
     assert loaded_data["state"].get_all() == {"foo": "bar"}
 
     # 2. Save and load again (different key/index) with partition key = None
-    mongodb_persister.save(None, "app_id_none2", 2, "pos2", state.State({"hello": "world"}), "completed")
+    mongodb_persister.save(
+        None, "app_id_none2", 2, "pos2", state.State({"hello": "world"}), "completed"
+    )
     loaded_data2 = mongodb_persister.load(None, "app_id_none2", 2)
     assert loaded_data2 is not None
     assert loaded_data2["state"].get_all() == {"hello": "world"}


### PR DESCRIPTION
This change was made because the default value for partition is None but the mongo persister did not have None in the type annotation. This change brings the function signature in line with the other persistors in the project that allow None as a valid value for the partition key.

## Changes

Changed partition key to optional.

## How I tested this

pytest -v tests/integrations/persisters/test_b_mongodb.py

![Screenshot 2025-02-05 at 1 14 23 AM](https://github.com/user-attachments/assets/b2b19970-8735-4672-817d-a41571cafe83)

## Notes

The partition_key default is None, so this will help to make it clear. 

Glad to be able to contribute! :)

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [none] New functions are documented (with a description, list of inputs, and expected output)
- [none] Placeholder code is flagged / future TODOs are captured in comments
- [none] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `partition_key` optional in `load` and `save` methods of `MongoDBBasePersister`, with tests for `None` value.
> 
>   - **Behavior**:
>     - `partition_key` argument in `load()` and `save()` methods of `MongoDBBasePersister` is now optional.
>     - Default value for `partition_key` is `None`.
>   - **Tests**:
>     - Added `test_partition_key_is_optional()` in `test_b_mongodb.py` to verify `load()` and `save()` with `partition_key=None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for 78f5d4f5493f139ba95eeec89723c10f4729437d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->