### PR TITLE
Fixes missing column width on inline telemetry for selection 

### DIFF
--- a/telemetry/ui/src/components/routes/app/StepList.tsx
+++ b/telemetry/ui/src/components/routes/app/StepList.tsx
@@ -735,7 +735,7 @@ const StepSubTableRow = (props: {
               </div>
             )}
           </TableCell>
-          {props.displayAnnotations && <TableCell className="" colSpan={2} />}
+          {<TableCell className="" colSpan={2} />}
         </>
       ) : (
         <TableCell colSpan={5}></TableCell>


### PR DESCRIPTION
We were special casing the missing annotations case but had already corrected for it elsewhere it would appear.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `StepSubTableRow` in `StepList.tsx` to always render a `TableCell` regardless of `displayAnnotations`.
> 
>   - **Behavior**:
>     - In `StepList.tsx`, `StepSubTableRow` component always renders a `TableCell` with `colSpan={2}` regardless of `props.displayAnnotations`.
>   - **Misc**:
>     - Removed unnecessary conditional check for `displayAnnotations` in `StepSubTableRow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for a1803e5816112f99280e4ae31297ed592a98870f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->