### PR TITLE
Adds API for streaming and iterating at the same time

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -1843,6 +1843,85 @@ class Application(Generic[ApplicationStateType]):
         )
 
     @telemetry.capture_function_usage
+    @_call_execute_method_pre_post(ExecuteMethod.stream_iterate)
+    def stream_iterate(
+        self,
+        halt_after: Optional[Union[str, List[str]]] = None,
+        halt_before: Optional[Union[str, List[str]]] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+    ) -> Generator[
+        Tuple[Action, StreamingResultContainer[ApplicationStateType, Union[dict, Any]]], None, None
+    ]:
+        """Produces an iterator that iterates through intermediate streams. You may want
+        to use this in something like deep research mode in which:
+
+        1. The user queries for a result
+        2. The application runs through a workflow
+        3. For each step of the workflow, the application
+            a. Streams out an intermediate result
+            b. Selects the next action/transition when the intermediate results is complete
+
+        Note that there are control-flow complexities involved here -- we need to ensure that the iterator
+        is properly pushed along and the prior streaming results containers are all finished before going to the next one.
+
+        :param halt_after: Action names/tags to halt before
+        :param halt_before: _description_, defaults to None
+        :param inputs: _description_, defaults to None
+        :return: _description_
+        :yield: _description_
+        """
+        self.validate_correct_async_use()
+        halt_before, halt_after, inputs = self._process_control_flow_params(
+            halt_before, halt_after, inputs
+        )
+        self._validate_halt_conditions(halt_before, halt_after)
+        while self.has_next_action():
+            next_action = self.get_next_action()
+            _, streaming_result = self.stream_result(
+                halt_after=[next_action.name], halt_before=None, inputs=inputs
+            )
+            yield next_action, streaming_result
+            # We need to ensure it's fully exhausted before going to the next action
+            streaming_result.get()
+            if self._should_halt_iterate(halt_before, halt_after, next_action):
+                break
+
+    @telemetry.capture_function_usage
+    @_call_execute_method_pre_post(ExecuteMethod.astream_iterate)
+    async def astream_iterate(
+        self,
+        halt_after: Optional[Union[str, List[str]]] = None,
+        halt_before: Optional[Union[str, List[str]]] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+    ) -> AsyncGenerator[
+        Tuple[Action, AsyncStreamingResultContainer[ApplicationStateType, Union[dict, Any]]], None
+    ]:
+        """Async version of stream_iterate. Produces an async generator that iterates
+        through intermediate streams. See stream_iterate for more details.
+
+        :param halt_after: Action names/tags to halt after the action completes
+        :param halt_before: Action names/tags to halt after
+        :param inputs: Inputs to the first action run
+        :return: Async generator yielding tuples of (action, streaming_result_container)
+        :yield: Tuples of (action, streaming_result_container)
+        """
+        self.validate_correct_async_use()
+        halt_before, halt_after, inputs = self._process_control_flow_params(
+            halt_before, halt_after, inputs
+        )
+        self._validate_halt_conditions(halt_before, halt_after)
+        while self.has_next_action():
+            next_action = self.get_next_action()
+            _, streaming_result = await self.astream_result(  # Use astream_result
+                halt_after=[next_action.name], halt_before=None, inputs=inputs
+            )
+            yield next_action, streaming_result
+            # We need to ensure it's fully exhausted before going to the next action
+            await streaming_result.get()  # await the get call
+            if self._should_halt_iterate(halt_before, halt_after, next_action):
+                break
+
+    @telemetry.capture_function_usage
     def visualize(
         self,
         output_file_path: Optional[str] = None,

--- a/burr/lifecycle/base.py
+++ b/burr/lifecycle/base.py
@@ -287,6 +287,8 @@ class ExecuteMethod(enum.Enum):
     arun = "arun"
     stream_result = "stream_result"
     astream_result = "astream_result"
+    stream_iterate = "stream_iterate"
+    astream_iterate = "astream_iterate"
 
 
 @lifecycle.base_hook("pre_run_execute_call")


### PR DESCRIPTION
This allows us to iterate over streaming outputs. E.G. for deep-research mode.

See #360

## Changes
- [x] Adds `stream_iterate`, `astream_iterate`
- [ ] Adds tests

## How I tested this
- [ ] Unit tests

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `stream_iterate` and `astream_iterate` methods to `Application` for synchronous and asynchronous streaming iteration, with corresponding tests.
> 
>   - **New Features**:
>     - Add `stream_iterate` and `astream_iterate` methods to `Application` in `application.py` for synchronous and asynchronous streaming iteration.
>   - **Lifecycle**:
>     - Add `stream_iterate` and `astream_iterate` to `ExecuteMethod` enum in `base.py`.
>   - **Testing**:
>     - Add `test_stream_iterate` and `test_astream_iterate` in `test_application.py` to verify behavior with both exhausted and non-exhausted intermediate generators.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for a7d43280ff7fa6d98a05da16431c7996c9615838. You can [customize](https://app.ellipsis.dev/DAGWorks-Inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->