### PR TITLE
Simplify running of release scripts with dependency groups

### DIFF
--- a/docs/contributing/setup.rst
+++ b/docs/contributing/setup.rst
@@ -47,6 +47,22 @@ Next you'll want to ``cd`` into the directory and install
     cd burr
     pip install -e ".[developer]"
 
+You can also use dependency group:
+
+.. code-block:: bash
+
+    pip install -e . --group dev
+
+or, if you use ``uv``:
+
+.. code-block:: bash
+
+    uv sync
+
+The latter command will automatically create and install virtual env if one does not exist and will
+automatically install the project in editable mode with all developer dependencies defined in dev
+dependency group.
+
 This will install all potential dependencies. Burr will work with ``python >=3.9``.
 
 ------------------

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -66,7 +66,6 @@ This installs the dependencies to run the burr CLI, i.e. `burr --help`.
 
 This installs all the dependencies for developing locally.
 
-
 .. code-block:: bash
 
     pip install "burr[documentation]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,12 @@ burr-admin-build-ui = "burr.cli.__main__:cli_build_ui"
 burr-admin-generate-demo-data = "burr.cli.__main__:cli_generate_demo_data"
 burr-test-case = "burr.cli.__main__:cli_test_case"
 
+[dependency-groups]
+dev = [
+  "apache-burr[cli]",
+  "flit",
+]
+
 [tool.flit.module]
 name = "burr"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -102,7 +102,7 @@ ls burr/tracking/server/build/  # Should NOT exist (no pre-built UI)
 
 # Create clean environment
 python -m venv venv && source venv/bin/activate
-pip install -e .
+pip install -e ".[cli]"
 pip install flit
 
 # Build artifacts and wheel (see step 3)
@@ -110,6 +110,25 @@ python scripts/build_artifacts.py all --clean
 ls dist/*.whl
 deactivate
 ```
+
+Alternatively, instead of manually creating the `venv` and installing burr with `pip install`, you can use
+`uv` and use simplified development workflow of uv you can  run the command directly:
+
+```bash
+uv run scripts/build_artifacts.py all --clean
+ls dist/*.whl
+```
+
+This will automatically:
+
+* download the right python version if you do not have python installed
+* create virtual environment in local `.venv` directory
+* activates the venv
+* installs `burr` in editable mode with `dev` dependency group (that contains `cli` extra, `developer` extra
+  and `flit` package.
+* deactivates the venv
+
+Next time when you run `uv run` it will also automatically sync the environment with latest `pyproject.toml`
 
 ## 3. Build Artifacts and Wheel
 


### PR DESCRIPTION
## Changes

While verifying the release, I realised that there were a small issue with setting up the environment - the installation instructions asked to install burr without extras in local dev env, but that was not enoughm you need to also install `cli` extra.

I have updated the docs appropriately, but also added an alternative workflow for running the installation scripts with `uv` and the standard "dependency groups". The dependency groups are already standardised and used by `uv` and others - for example to install dev dependency group automatically when `uv sync` is used.

This makes it as easy to run the scripts as possible without having all the venv manual installation and syncing (uv does it for you).

## How I tested this

Prepared a rlease locally without having venv setup, uv nicely built UI assets and wheel after just:

```bash
uv run python scripts/build_artifacts.py all --clean
```

Resulted with:

```
================================================================================
✅ Build Complete!
================================================================================

Wheel files are in the dist/ directory.
You can now upload to PyPI with:
  twine upload dist/*.whl
```

## Notes

You could consider adding `developer` extra also to the  `dev` dependency group or even converting some of your extras to dependency groups. The drawback of adding `apache-burr[developer]' to dependency group is that it will add a lot more packages, but it will also allow you to do this:

```
uv run pytest
```

Without any prerequisites - installing python, configuring venv, etc. It will **just** work 
There are some other errors when you do it now, but you can likely solve them easily to get it all **just** work.

In this case Instead of adding "apache-burr[cli]" and "flit" to dev dependency group you could add inline project metadata to the script (this is a very successful new way of specifying dependencies for scripts  https://peps.python.org/pep-0723/. 

Something like that in `scripts/build_artifacts.py`:

```toml
# /// script
# requires-python = ">=3.10"
# dependencies = [
#    "click",
#    "loguru",
#    "click", 
#    "requests"
#    "flit",
#    "..",
# ]
# ///
```

Then you could keep "dev" only install `deveioper` extra by default but when you run this:

```bash
uv run python scripts/build_artifacts.py all --clean
```

The `uv` or `hatch` or any other frontend that implements PEP-723 (will be there in the next version of `pip`) - will create a separate venv with only burr, click, requests, loguru and flit - just for the time of execution of the script (and cache it of course for next runs). 

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] Project documentation has been updated if adding/changing functionality.

N/A:

- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
