### PR TITLE
docs(deployments): add Vercel deployment guide (#390)

### DIFF
--- a/examples/deployment/vercel/README.md
+++ b/examples/deployment/vercel/README.md
@@ -1,3 +1,22 @@
+<!--
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+-->
+
 # Deploy Burr in Vercel
 
 [Vercel](https://vercel.com/) - serverless platform for frontend frameworks and serverless functions.

--- a/examples/deployment/vercel/api/counter.py
+++ b/examples/deployment/vercel/api/counter.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 """
 Vercel Serverless Function for counter application
 Endpoint: /api/counter

--- a/examples/deployment/vercel/app/__init__.py
+++ b/examples/deployment/vercel/app/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/examples/deployment/vercel/app/counter_app.py
+++ b/examples/deployment/vercel/app/counter_app.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 """
 This is a very simple counting application.
 

--- a/examples/deployment/vercel/requirements.txt
+++ b/examples/deployment/vercel/requirements.txt
@@ -1,1 +1,2 @@
 burr
+# for tracking you'd add extra dependencies


### PR DESCRIPTION
## Changes
Adding the first part of #390 — deploying Burr applications to Vercel (serverless, one-click).

This PR introduces:
- `examples/deployment/vercel/README.md` with step-by-step instructions
- `POST` test examples

## How I tested this
Tested & verified on a free Vercel account: https://test-burr-vercel.vercel.app

Demo request works:
```bash
curl -X POST https://test-burr-vercel.vercel.app/api/counter \
  -H "Content-Type: application/json" \
  -d '{"number": 5}'
```

## Notes
Developers could use 2 methods:
- Vercel CLI
- GitHub Link

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.

N/A:  (Since this PR is used for deployment, no functionality changes are included.)
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
