### PR TITLE
fix(pydantic): improve error message for untyped state parameter

### DIFF
--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -129,14 +129,17 @@ def _validate_and_extract_signature_types(
             "action must be the state object. Got signature: {sig}."
         )
     type_hints = typing.get_type_hints(fn)
+    state_model = type_hints.get("state")
 
-    if (state_model := type_hints["state"]) is inspect.Parameter.empty or not issubclass(
-        state_model, pydantic.BaseModel
+    if (
+        state_model is None
+        or state_model is inspect.Parameter.empty
+        or not issubclass(state_model, pydantic.BaseModel)
     ):
         raise ValueError(
             f"Function fn: {fn.__qualname__} is not a valid pydantic action. "
-            "a type annotation of a type extending: pydantic.BaseModel. Got parameter "
-            "state: {state_model.__qualname__}."
+            "The 'state' parameter must be annotated with a type extending pydantic.BaseModel. "
+            f"Got: {state_model}."
         )
     if (ret_hint := type_hints.get("return")) is None or not issubclass(
         ret_hint, pydantic.BaseModel

--- a/tests/integrations/test_burr_pydantic.py
+++ b/tests/integrations/test_burr_pydantic.py
@@ -185,6 +185,10 @@ def _fn_with_no_return_type(state: OriginalModel):
     ...
 
 
+def _fn_with_untyped_state_arg(state) -> OriginalModel:
+    ...
+
+
 def _fn_correct_same_itype_otype(state: OriginalModel, input_1: int) -> OriginalModel:
     ...
 
@@ -200,11 +204,19 @@ def _fn_correct_diff_itype_otype(state: OriginalModel, input_1: int) -> NestedMo
         (_fn_with_incorrect_state_arg, ValueError),
         (_fn_with_incorrect_return_type, ValueError),
         (_fn_with_no_return_type, ValueError),
+        (_fn_with_untyped_state_arg, ValueError),
     ],
 )
 def test__validate_and_extract_signature_types_error(fn, expected_exception):
     with pytest.raises(expected_exception=expected_exception):
         _validate_and_extract_signature_types(fn)
+
+
+def test__validate_and_extract_signature_types_untyped_state_error_message():
+    """Test that the error message is informative when state is not type-annotated."""
+    with pytest.raises(ValueError) as excinfo:
+        _validate_and_extract_signature_types(_fn_with_untyped_state_arg)
+    assert "'state' parameter must be annotated" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Fixed uninformative KeyError when pydantic_action has untyped state parameter
- Now raises clear ValueError explaining the state parameter must be annotated

## Changes
- Changed `type_hints["state"]` to `type_hints.get("state")` to avoid KeyError
- Updated error message to clearly state: "'state' parameter must be annotated with a type extending pydantic.BaseModel"

## Test plan
- [x] Added test function `_fn_with_untyped_state_arg` and parameterized test case
- [x] Added `test__validate_and_extract_signature_types_untyped_state_error_message` to verify error message
- [x] All existing pydantic tests pass (32 tests)
- [x] Pre-commit checks pass

Closes #385