### PR TITLE
Update OpenAI model in email assistant example

### DIFF
--- a/examples/email-assistant/application.py
+++ b/examples/email-assistant/application.py
@@ -54,7 +54,7 @@ def determine_clarifications(state: State) -> State:
     client = _get_openai_client()
     # TODO -- use instructor to get a pydantic model
     result = client.chat.completions.create(
-        model="gpt-4",
+        model="gpt-4o-mini",
         messages=[
             {
                 "role": "system",
@@ -130,7 +130,7 @@ def formulate_draft(state: State) -> Tuple[dict, State]:
     prompt = " ".join(instructions)
 
     result = client.chat.completions.create(
-        model="gpt-4",
+        model="gpt-4o-mini",
         messages=[
             {
                 "role": "system",


### PR DESCRIPTION
Partially implements #521

This PR updates the email assistant example to replace deprecated OpenAI
model usage with a current recommended model.

## Changes
- Updated `examples/email-assistant/application.py`
- Replaced `gpt-4` with `gpt-4o-mini`

## How I tested this
- Verified the example runs without runtime errors locally

## Notes
- Example-only change
- No core Burr logic modified
