### PR TITLE
fix(pydantic): accept union type objects for stream_type hints

### DIFF
--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -62,6 +62,18 @@ if TYPE_CHECKING:
     except ImportError:
         pass
 
+try:
+    UnionType = types.UnionType
+except AttributeError:  # py<3.10
+    UnionType = None
+
+if typing.TYPE_CHECKING:
+    StreamingPydanticType = Any
+else:
+    StreamingPydanticType = Union[Type["BaseModel"], Type[dict]]
+    if UnionType is not None:
+        StreamingPydanticType = Union[Type["BaseModel"], Type[dict], UnionType]
+
 
 class Function(abc.ABC):
     """Interface to represent the 'computing' part of an action"""
@@ -1309,7 +1321,7 @@ class streaming_action:
         writes: List[str],
         state_input_type: Type["BaseModel"],
         state_output_type: Type["BaseModel"],
-        stream_type: Union[Type["BaseModel"], Type[dict]],
+        stream_type: "StreamingPydanticType",
         tags: Optional[List[str]] = None,
     ) -> Callable:
         """Creates a streaming action that uses pydantic models.

--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -22,6 +22,7 @@ import inspect
 import types
 import typing
 from typing import (
+    Any,
     AsyncGenerator,
     Awaitable,
     Callable,
@@ -264,7 +265,17 @@ def pydantic_action(
     return decorator
 
 
-PartialType = Union[Type[pydantic.BaseModel], Type[dict]]
+try:
+    UnionType = types.UnionType
+except AttributeError:  # py<3.10
+    UnionType = None
+
+if typing.TYPE_CHECKING:
+    PartialType = Any
+else:
+    PartialType = Union[Type[pydantic.BaseModel], Type[dict]]
+    if UnionType is not None:
+        PartialType = Union[Type[pydantic.BaseModel], Type[dict], UnionType]
 
 PydanticStreamingActionFunctionSync = Callable[
     ..., Generator[Tuple[Union[pydantic.BaseModel, dict], Optional[pydantic.BaseModel]], None, None]
@@ -285,12 +296,10 @@ PydanticStreamingActionFunctionVar = TypeVar(
 
 def _validate_and_extract_signature_types_streaming(
     fn: PydanticStreamingActionFunction,
-    stream_type: Optional[Union[Type[pydantic.BaseModel], Type[dict]]],
+    stream_type: Optional[PartialType],
     state_input_type: Optional[Type[pydantic.BaseModel]] = None,
     state_output_type: Optional[Type[pydantic.BaseModel]] = None,
-) -> Tuple[
-    Type[pydantic.BaseModel], Type[pydantic.BaseModel], Union[Type[dict], Type[pydantic.BaseModel]]
-]:
+) -> Tuple[Type[pydantic.BaseModel], Type[pydantic.BaseModel], PartialType]:
     if stream_type is None:
         # TODO -- derive from the signature
         raise ValueError(f"stream_type is required for function: {fn.__qualname__}")


### PR DESCRIPTION
## Summary
- treat union type objects as valid stream_type values for pydantic streaming actions
- keep runtime behavior unchanged while relaxing type hints for union-type streams

## Testing
- not run (type-hint only change)