### PR TITLE
Update OpenAI model in deep researcher example

### DIFF
--- a/examples/deep-researcher/application.py
+++ b/examples/deep-researcher/application.py
@@ -68,7 +68,7 @@ def query_openai(system_instructions, human_message_content, stream=False):
     messages.append(system_message)
     messages.append(human_message)
 
-    response = client.chat.completions.create(model="gpt-4o", messages=messages, stream=stream)
+    response = client.chat.completions.create(model="gpt-4o-mini", messages=messages, stream=stream)
     content = response.choices[0].message.content
     return content
 


### PR DESCRIPTION
Part of #521

This PR updates the OpenAI model used in the deep researcher example to the latest supported model.

### Change
- Replaced `gpt-4o` with `gpt-4o-mini` in:
  - `examples/deep-researcher/application.py`

### Testing
- Installed example dependencies
- Ran the example locally
- Application initializes and executes until Graphviz rendering
- Graphviz error on Windows is expected (system dependency) and unrelated to the model change

Screenshots of local run are provided in the PR comments.
