### PR TITLE
Update copyright year in NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Burr (Incubating)
-Copyright 2026 The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
I think it is more standard to not move the base year in the copyright.

I asked Claude AI and it suggested that even just leaving the year at 2025 is better than updating to 2026 and dropping the 2025 - but that 2025-2026 was best.