### PR TITLE
fix: set minimum pydantic version to 2.11 to avoid model_fields depreciations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ tests = [
   "langchain_core",
   "langchain_community",
   "pandas",
-  "pydantic[email]",
+  "pydantic[email]>=2.11",
   "pyarrow",
   "apache-burr[aiosqlite]",
   "apache-burr[asyncpg]",
@@ -135,7 +135,7 @@ documentation = [
 ]
 
 tracking-client = [
-  "pydantic>1"
+  "pydantic>=2.11"
 ]
 
 tracking-client-s3 = [
@@ -156,7 +156,7 @@ tracking-server = [
   "click",
   "fastapi",
   "uvicorn",
-  "pydantic",
+  "pydantic>=2.11",
   "pydantic-settings",
   "fastapi-pagination",
   "fastapi-utils",
@@ -168,7 +168,7 @@ tracking-server = [
 ]
 
 pydantic = [
-  "pydantic"
+  "pydantic>=2.11"
 ]
 
 haystack = [


### PR DESCRIPTION
This pull request updates the `pydantic` dependency version to ensure consistency and compatibility across multiple extras in the `pyproject.toml` file. All references to `pydantic` are now set to require version 2.11 or higher.

Dependency version updates:

* Updated the `pydantic` dependency to require `>=2.11` in the `tests`, `tracking-client`, `tracking-server`, and `pydantic` extras sections of `pyproject.toml` to standardize the minimum version used throughout the project. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L107-R107) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L138-R138) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L159-R159) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L171-R171)=
