### PR TITLE
fix: access model_fields from class instead of instance

### DIFF
--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -51,8 +51,10 @@ PydanticActionFunction = Callable[..., Union[pydantic.BaseModel, Awaitable[pydan
 
 def model_to_dict(model: pydantic.BaseModel, include: Optional[List[str]] = None) -> dict:
     """Utility function to convert a pydantic model to a dictionary."""
-    keys = model.model_fields.keys()
-    keys = keys if include is None else [item for item in include if item in model.model_fields]
+    keys = type(model).model_fields.keys()
+    keys = (
+        keys if include is None else [item for item in include if item in type(model).model_fields]
+    )
     return {key: getattr(model, key) for key in keys}
 
 


### PR DESCRIPTION
Fixes deprecation warning in Pydantic 2.11+ where accessing model_fields on an instance is deprecated. Changed to use type(model).model_fields in model_to_dict().

Closes #652 


## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
