### PR TITLE
Add comparison operators to when() conditions

### DIFF
--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -433,6 +433,8 @@ class Condition(Function):
         "in": ("in", lambda a, b: a in b),
         "notin": ("not in", lambda a, b: a not in b),
         "contains": ("contains", lambda a, b: b in a),
+        "is": ("is", lambda a, b: a is b),
+        "isnot": ("is not", lambda a, b: a is not b),
     }
 
     @classmethod
@@ -481,6 +483,11 @@ class Condition(Function):
             when(status__in=["a", "b"])     # state["status"] in ["a", "b"]
             when(status__notin=["x", "y"])  # state["status"] not in ["x", "y"]
             when(tags__contains="python")   # "python" in state["tags"]
+
+        Identity operators::
+
+            when(value__is=None)            # state["value"] is None
+            when(value__isnot=None)         # state["value"] is not None
 
         Multiple conditions are ANDed together::
 

--- a/docs/concepts/transitions.rst
+++ b/docs/concepts/transitions.rst
@@ -67,6 +67,8 @@ Conditions have a few APIs, but the most common are the three convenience functi
         ("check", "tagged", when(tags__contains="python")),  # collection contains value
         ("check", "clean", when(status__notin=["banned", "suspended"])),  # not in
         ("check", "changed", when(status__ne="initial")),  # not equal
+        ("check", "missing", when(value__is=None)),  # identity check
+        ("check", "present", when(value__isnot=None)),  # not-identity check
     )
 
 Available operators:
@@ -81,6 +83,8 @@ Available operators:
 - ``key__in=[values]`` — value is in the given collection
 - ``key__notin=[values]`` — value is not in the given collection
 - ``key__contains=value`` — collection/string in state contains the value
+- ``key__is=value`` — identity check (``is``), useful for ``None``/``True``/``False``
+- ``key__isnot=value`` — negated identity check (``is not``)
 
 Multiple keyword arguments are ANDed together. For more complex expressions, use ``expr()``.
 

--- a/tests/core/test_action.py
+++ b/tests/core/test_action.py
@@ -166,6 +166,14 @@ def test_condition_when_complex():
         ({"tags__contains": "go"}, {"tags": ["python", "java"]}, False),
         ({"text__contains": "hello"}, {"text": "say hello world"}, True),
         ({"text__contains": "goodbye"}, {"text": "say hello world"}, False),
+        # __is (identity)
+        ({"value__is": None}, {"value": None}, True),
+        ({"value__is": None}, {"value": 0}, False),
+        ({"value__is": True}, {"value": True}, True),
+        ({"value__is": True}, {"value": 1}, False),
+        # __isnot (not identity)
+        ({"value__isnot": None}, {"value": "hello"}, True),
+        ({"value__isnot": None}, {"value": None}, False),
     ],
     ids=[
         "eq-match",
@@ -193,6 +201,12 @@ def test_condition_when_complex():
         "contains-list-no-match",
         "contains-str-match",
         "contains-str-no-match",
+        "is-none-match",
+        "is-none-no-match",
+        "is-true-match",
+        "is-true-not-identical",
+        "isnot-not-none",
+        "isnot-is-none",
     ],
 )
 def test_condition_when_operators(kwargs, state_dict, expected):
@@ -226,11 +240,13 @@ def test_condition_when_operators_reads(kwargs, expected_reads):
         ({"status__in": ["a", "b"]}, "status in ['a', 'b']"),
         ({"status__notin": ["x"]}, "status not in ['x']"),
         ({"tags__contains": "py"}, "tags contains 'py'"),
+        ({"value__is": None}, "value is None"),
+        ({"value__isnot": None}, "value is not None"),
         # plain equality still uses old format
         ({"foo": "bar"}, "foo=bar"),
         ({"foo": "bar", "baz": "qux"}, "baz=qux, foo=bar"),
     ],
-    ids=["gte", "lt", "ne", "in", "notin", "contains", "plain-eq", "plain-multi"],
+    ids=["gte", "lt", "ne", "in", "notin", "contains", "is", "isnot", "plain-eq", "plain-multi"],
 )
 def test_condition_when_operators_name(kwargs, expected_name):
     cond = Condition.when(**kwargs)


### PR DESCRIPTION
 ## Summary

- Extends `Condition.when()` to support Django-style lookup operators via `__` suffixes
- Fully backward compatible — plain `when(key=value)` behavior is unchanged
- Adds 43 parametrized tests covering all operators, edge cases, and composition
- Updates transition documentation with operator reference

## Supported Operators

```python
from burr.core import when

when(age__gte=18)                          # age >= 18
when(age__gt=18)                           # age > 18
when(age__lt=18)                           # age < 18
when(age__lte=18)                          # age <= 18
when(age__ne=0)                            # age != 0
when(age__eq=18)                           # age == 18 (explicit)
when(status__in=["active", "pending"])     # membership
when(status__notin=["banned"])             # not in
when(tags__contains="python")              # collection contains value
```

Multiple kwargs are ANDed: `when(age__gte=18, status="active")`

Works with `~` (invert), `|` (or), and `&` (and) operators.

## Motivation

Previously, `when()` only supported exact equality. Users had to fall back to `expr()` string expressions for any comparison, losing type safety and IDE support. This change makes the most common comparison patterns expressible directly in `when()`.

## Test plan

- [x] All 12 existing condition tests pass unchanged (backward compat)
- [x] 25 parametrized operator tests (all operators × true/false cases)
- [x] 5 reads-extraction tests (single key, multiple keys, same key with two operators)
- [x] 8 name-formatting tests (symbol operators, word operators, plain equality)
- [x] Combined multi-operator test
- [x] Composition tests (~, |, &)
- [x] Invalid key validation test
- [x] Full test suite: 93 passed
     

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
