### PR TITLE
core: add flexible_api decorator to fix mypy override errors

### DIFF
--- a/burr/core/__init__.py
+++ b/burr/core/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from burr.core.action import Action, Condition, Result, action, default, expr, flexible_api, when
+from burr.core.action import Action, Condition, Result, action, default, expr, type_eraser, when
 from burr.core.application import (
     Application,
     ApplicationBuilder,
@@ -35,7 +35,7 @@ __all__ = [
     "Condition",
     "default",
     "expr",
-    "flexible_api",
+    "type_eraser",
     "Result",
     "State",
     "when",

--- a/burr/core/__init__.py
+++ b/burr/core/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from burr.core.action import Action, Condition, Result, action, default, expr, when
+from burr.core.action import Action, Condition, Result, action, default, expr, flexible_api, when
 from burr.core.application import (
     Application,
     ApplicationBuilder,
@@ -35,6 +35,7 @@ __all__ = [
     "Condition",
     "default",
     "expr",
+    "flexible_api",
     "Result",
     "State",
     "when",

--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -143,6 +143,7 @@ def flexible_api(func: Callable[..., Any]) -> Callable[..., Any]:
 
     return wrapper
 
+
 # This is here to make accessing the pydantic actions easier
 # we just attach them to action so you can call `@action.pyddantic...`
 # The IDE will like it better and thus be able to auto-complete/type-check

--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -105,7 +105,7 @@ from functools import wraps
 from burr.core.typing import ActionSchema
 
 
-def flexible_api(func: Callable[..., Any]) -> Callable[..., Any]:
+def type_eraser(func: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator for ``run``, ``stream_run``, and ``run_and_update`` overrides
     that declare explicit parameters instead of ``**run_kwargs``.
 
@@ -114,14 +114,14 @@ def flexible_api(func: Callable[..., Any]) -> Callable[..., Any]:
 
     Example usage::
 
-        from burr.core import Action, State, flexible_api
+        from burr.core import Action, State, type_eraser
 
         class Counter(Action):
             @property
             def reads(self) -> list[str]:
                 return ["counter"]
 
-            @flexible_api
+            @type_eraser
             def run(self, state: State, increment_by: int) -> dict:
                 return {"counter": state["counter"] + increment_by}
 
@@ -136,6 +136,31 @@ def flexible_api(func: Callable[..., Any]) -> Callable[..., Any]:
             def inputs(self) -> list[str]:
                 return ["increment_by"]
     """
+
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            return await func(*args, **kwargs)
+
+        return async_wrapper
+
+    if inspect.isasyncgenfunction(func):
+
+        @wraps(func)
+        async def async_gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+            async for item in func(*args, **kwargs):
+                yield item
+
+        return async_gen_wrapper
+
+    if inspect.isgeneratorfunction(func):
+
+        @wraps(func)
+        def gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+            yield from func(*args, **kwargs)
+
+        return gen_wrapper
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -100,7 +100,48 @@ def _validate_declared_reads(fn: Callable, declared_reads: list[str]) -> None:
         )
 
 
+from functools import wraps
+
 from burr.core.typing import ActionSchema
+
+
+def flexible_api(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator for ``run``, ``stream_run``, and ``run_and_update`` overrides
+    that declare explicit parameters instead of ``**run_kwargs``.
+
+    Applying this decorator prevents mypy ``[override]`` errors caused by
+    narrowing the base-class signature (which uses ``**run_kwargs``).
+
+    Example usage::
+
+        from burr.core import Action, State, flexible_api
+
+        class Counter(Action):
+            @property
+            def reads(self) -> list[str]:
+                return ["counter"]
+
+            @flexible_api
+            def run(self, state: State, increment_by: int) -> dict:
+                return {"counter": state["counter"] + increment_by}
+
+            @property
+            def writes(self) -> list[str]:
+                return ["counter"]
+
+            def update(self, result: dict, state: State) -> State:
+                return state.update(**result)
+
+            @property
+            def inputs(self) -> list[str]:
+                return ["increment_by"]
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    return wrapper
 
 # This is here to make accessing the pydantic actions easier
 # we just attach them to action so you can call `@action.pyddantic...`

--- a/tests/core/test_action.py
+++ b/tests/core/test_action.py
@@ -38,6 +38,7 @@ from burr.core.action import (
     default,
     derive_inputs_from_fn,
     streaming_action,
+    type_eraser,
 )
 
 
@@ -878,3 +879,143 @@ def test_pydantic_action_not_impacted():
     from burr.core.action import create_action
 
     create_action(good_action, name="test")
+
+
+class TestTypeEraser:
+    def test_sync_run(self):
+        class MyAction(Action):
+            @property
+            def reads(self) -> list[str]:
+                return ["counter"]
+
+            @type_eraser
+            def run(self, state: State, increment_by: int) -> dict:
+                return {"counter": state["counter"] + increment_by}
+
+            @property
+            def writes(self) -> list[str]:
+                return ["counter"]
+
+            def update(self, result: dict, state: State) -> State:
+                return state.update(**result)
+
+            @property
+            def inputs(self) -> list[str]:
+                return ["increment_by"]
+
+        a = MyAction()
+        result = a.run(State({"counter": 0}), increment_by=5)
+        assert result == {"counter": 5}
+        assert a.is_async() is False
+
+    def test_async_run(self):
+        class MyAsyncAction(Action):
+            @property
+            def reads(self) -> list[str]:
+                return ["counter"]
+
+            @type_eraser
+            async def run(self, state: State, increment_by: int) -> dict:
+                return {"counter": state["counter"] + increment_by}
+
+            @property
+            def writes(self) -> list[str]:
+                return ["counter"]
+
+            def update(self, result: dict, state: State) -> State:
+                return state.update(**result)
+
+            @property
+            def inputs(self) -> list[str]:
+                return ["increment_by"]
+
+        a = MyAsyncAction()
+        assert a.is_async() is True
+        result = asyncio.run(a.run(State({"counter": 0}), increment_by=5))
+        assert result == {"counter": 5}
+
+    def test_sync_stream_run(self):
+        class MyStreamingAction(StreamingAction):
+            @property
+            def reads(self) -> list[str]:
+                return ["items"]
+
+            @type_eraser
+            def stream_run(self, state: State, prefix: str) -> Generator[dict, None, None]:
+                for item in state["items"]:
+                    yield {"val": f"{prefix}_{item}"}
+
+            @property
+            def writes(self) -> list[str]:
+                return ["result"]
+
+            def update(self, result: dict, state: State) -> State:
+                return state.update(**result)
+
+            @property
+            def inputs(self) -> list[str]:
+                return ["prefix"]
+
+        a = MyStreamingAction()
+        results = list(a.stream_run(State({"items": ["a", "b"]}), prefix="x"))
+        assert results == [{"val": "x_a"}, {"val": "x_b"}]
+
+    def test_async_stream_run(self):
+        class MyAsyncStreamingAction(AsyncStreamingAction):
+            @property
+            def reads(self) -> list[str]:
+                return ["items"]
+
+            @type_eraser
+            async def stream_run(self, state: State, prefix: str) -> AsyncGenerator[dict, None]:
+                for item in state["items"]:
+                    yield {"val": f"{prefix}_{item}"}
+
+            @property
+            def writes(self) -> list[str]:
+                return ["result"]
+
+            def update(self, result: dict, state: State) -> State:
+                return state.update(**result)
+
+            @property
+            def inputs(self) -> list[str]:
+                return ["prefix"]
+
+        a = MyAsyncStreamingAction()
+        assert a.is_async() is True
+
+        async def collect():
+            return [item async for item in a.stream_run(State({"items": ["a", "b"]}), prefix="x")]
+
+        results = asyncio.run(collect())
+        assert results == [{"val": "x_a"}, {"val": "x_b"}]
+
+    def test_preserves_wrapped_name(self):
+        class MyAction(Action):
+            @property
+            def reads(self) -> list[str]:
+                return []
+
+            @type_eraser
+            def run(self, state: State, custom_param: str) -> dict:
+                return {}
+
+            @property
+            def writes(self) -> list[str]:
+                return []
+
+            def update(self, result: dict, state: State) -> State:
+                return state
+
+            @property
+            def inputs(self) -> list[str]:
+                return []
+
+        assert MyAction().run.__name__ == "run"
+        assert MyAction().run.__wrapped__.__name__ == "run"
+
+    def test_exported_from_burr_core(self):
+        from burr.core import type_eraser as te
+
+        assert te is type_eraser


### PR DESCRIPTION
## Summary

- Adds a `flexible_api` decorator that can be applied to `run`, `stream_run`, or `run_and_update` overrides using explicit parameters instead of `**run_kwargs`
- Prevents mypy `[override]` errors caused by narrowing the base-class signature
- Exported from `burr.core` for easy access

## Context

When users define class-based actions with typed parameters in `run()` (which is the documented pattern), mypy reports an `[override]` error because the subclass signature is incompatible with `Function.run(self, state, **run_kwargs)`.

The decorator wraps the method so mypy sees `Callable[..., Any]`, which is compatible with the base signature.

### Before (triggers mypy error)
```python
class Counter(Action):
    def run(self, state: State, increment_by: int) -> dict:  # mypy: [override]
        return {"counter": state["counter"] + increment_by}
```

### After (no mypy error)
```python
from burr.core import flexible_api

class Counter(Action):
    @flexible_api
    def run(self, state: State, increment_by: int) -> dict:  # ok
        return {"counter": state["counter"] + increment_by}
```

## Test plan

- Tested in isolated Docker environment (Python 3.12, mypy 1.19.1) confirming the decorator eliminates the `[override]` error
- Class without decorator still triggers the error as expected (no behavior change for existing code)

Closes #457