### PR TITLE
fix: instantiate instrumentor in init_instruments()

### DIFF
--- a/burr/integrations/opentelemetry.py
+++ b/burr/integrations/opentelemetry.py
@@ -665,7 +665,8 @@ def _init_instrument(
 
     try:
         instrumentation_module = importlib.import_module(instrumentation_module_name)
-        instrumentor = getattr(instrumentation_module, instrumentor_name)
+        instrumentor_cls = getattr(instrumentation_module, instrumentor_name)
+        instrumentor = instrumentor_cls()
         if instrumentor.is_instrumented_by_opentelemetry:
             logger.debug(f"`{module_name}` is already instrumented.")
         else:


### PR DESCRIPTION
## Summary
- `_init_instrument` was calling `.is_instrumented_by_opentelemetry` and `.instrument()` on the **class** instead of an **instance**
- The `property` descriptor on the class is always truthy, so instrumentation was silently skipped with a `"is already instrumented"` debug log
- Even if it reached `.instrument()`, the call would fail with `TypeError: missing 1 required positional argument: 'self'`, caught and swallowed by the bare `except BaseException`

Fixes the class reference to instantiate it first, matching the standard OpenTelemetry instrumentor API.

Closes #408

## Test plan
- [x] Reproduced in a clean Docker container (Python 3.11, burr 0.41.0, opentelemetry-instrumentation-openai) confirming `is_instrumented_by_opentelemetry = False` after `init_instruments("openai")`
- [x] Applied fix and verified `is_instrumented_by_opentelemetry = True` after `init_instruments("openai")`