### PR TITLE
fix: async interceptor should_intercept must be sync + temporal example fixes

### DIFF
--- a/burr/lifecycle/base.py
+++ b/burr/lifecycle/base.py
@@ -709,13 +709,17 @@ class ActionExecutionInterceptorHookAsync(abc.ABC):
     """Async version of ActionExecutionInterceptorHook for intercepting async actions."""
 
     @abc.abstractmethod
-    async def should_intercept(
+    def should_intercept(
         self,
         *,
         action: "Action",
         **future_kwargs: Any,
     ) -> bool:
         """Determine if this action should be intercepted.
+
+        Note: This method is intentionally synchronous even on async interceptors.
+        It is a pure predicate used inside lambdas that cannot be awaited. If you
+        need I/O to decide, cache the result during __init__ or pre_run_step.
 
         :param action: Action to potentially intercept
         :param future_kwargs: Future keyword arguments
@@ -799,13 +803,17 @@ class StreamingActionInterceptorHookAsync(abc.ABC):
     """Async version for intercepting async streaming actions."""
 
     @abc.abstractmethod
-    async def should_intercept(
+    def should_intercept(
         self,
         *,
         action: "Action",
         **future_kwargs: Any,
     ) -> bool:
         """Determine if this streaming action should be intercepted.
+
+        Note: This method is intentionally synchronous even on async interceptors.
+        It is a pure predicate used inside lambdas that cannot be awaited. If you
+        need I/O to decide, cache the result during __init__ or pre_run_step.
 
         :param action: Streaming action to potentially intercept
         :param future_kwargs: Future keyword arguments
@@ -814,7 +822,7 @@ class StreamingActionInterceptorHookAsync(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def intercept_stream_run_and_update(
+    async def intercept_stream_run_and_update(
         self,
         *,
         action: "Action",

--- a/examples/remote-execution-temporal/temporal_interceptor.py
+++ b/examples/remote-execution-temporal/temporal_interceptor.py
@@ -113,7 +113,7 @@ class TemporalInterceptor(ActionExecutionInterceptorHookAsync):
             self._client = await Client.connect("localhost:7233")
         return self._client
 
-    async def should_intercept(self, *, action: Action, **future_kwargs: Any) -> bool:
+    def should_intercept(self, *, action: Action, **future_kwargs: Any) -> bool:
         """Intercept actions tagged with 'durable'."""
         return hasattr(action, "tags") and "durable" in getattr(action, "tags", {})
 
@@ -142,12 +142,12 @@ class TemporalInterceptor(ActionExecutionInterceptorHookAsync):
         # Call worker hooks if provided
         worker_adapter_set = future_kwargs.get("worker_adapter_set")
         if worker_adapter_set:
-            for hook in worker_adapter_set.get_hooks(PreRunStepHookWorkerAsync):
-                await hook.pre_run_step_worker(
-                    action=action.name,
-                    state=state,
-                    inputs=inputs,
-                )
+            await worker_adapter_set.call_all_lifecycle_hooks_async(
+                "pre_run_step_worker",
+                action=action,
+                state=state,
+                inputs=inputs,
+            )
 
         # Execute as Temporal activity
         result_data = await client.execute_workflow(
@@ -167,12 +167,13 @@ class TemporalInterceptor(ActionExecutionInterceptorHookAsync):
 
         # Call post-run worker hooks
         if worker_adapter_set:
-            for hook in worker_adapter_set.get_hooks(PostRunStepHookWorkerAsync):
-                await hook.post_run_step_worker(
-                    action=action.name,
-                    state=state,
-                    result=result,
-                )
+            await worker_adapter_set.call_all_lifecycle_hooks_async(
+                "post_run_step_worker",
+                action=action,
+                state=state,
+                result=result,
+                exception=None,
+            )
 
         # For single-step actions, wrap state update
         if hasattr(action, "single_step") and action.single_step:
@@ -189,14 +190,22 @@ class TemporalWorkerLogger(PreRunStepHookWorkerAsync, PostRunStepHookWorkerAsync
     """Example worker hook that logs action execution on the Temporal worker side."""
 
     async def pre_run_step_worker(
-        self, *, action: str, state: "State", inputs: Dict[str, Any], **kwargs
+        self, *, action: Action, state: "State", inputs: Dict[str, Any], **future_kwargs
     ):
         """Log before action runs on worker."""
-        logger.info(f"[Worker Hook] PRE: {action}")
+        logger.info(f"[Worker Hook] PRE: {action.name}")
 
-    async def post_run_step_worker(self, *, action: str, state: "State", result: dict, **kwargs):
+    async def post_run_step_worker(
+        self,
+        *,
+        action: Action,
+        state: "State",
+        result: dict,
+        exception: Exception,
+        **future_kwargs,
+    ):
         """Log after action runs on worker."""
-        logger.info(f"[Worker Hook] POST: {action} -> {list(result.keys())}")
+        logger.info(f"[Worker Hook] POST: {action.name} -> {list(result.keys())}")
 
 
 # --- Example Application ---


### PR DESCRIPTION
## Summary

Fixes bugs in the interceptor lifecycle hooks introduced in #602:

- **`should_intercept` on async interceptor classes was declared `async def`**, but callers use it inside lambdas passed to `get_first_matching_hook()` which cannot `await`. An async `should_intercept` returns a coroutine object (always truthy), silently matching every action regardless of the predicate logic. Changed to `def` with a note explaining why.
- **`StreamingActionInterceptorHookAsync.intercept_stream_run_and_update`** was `def` but the caller checks `isasyncgenfunction`, so it needs to be `async def` to match.
- **Temporal example** called `worker_adapter_set.get_hooks()` which doesn't exist on `LifecycleAdapterSet`. Replaced with `call_all_lifecycle_hooks_async()`.
- **Temporal worker hook signatures** used `str` for action and `**kwargs` instead of `Action` and `**future_kwargs`.

## Test plan

- [x] All 311 tests pass (core + lifecycle + interceptor integration tests)
- [x] No changes to test files needed (tests already used sync `should_intercept`)
- [x] Verified no remaining `async def should_intercept` in codebase