### PR TITLE
fix: clean wheel contents and update .rat-excludes for release

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -33,5 +33,14 @@ website/src/components/ui/.*\.tsx
 # SVG files (third-party logos and graphics, headers impractical)
 .*\.svg
 
+# GitHub templates and config (YAML/MD with frontmatter, headers impractical)
+\.github/.*
+
+# Image files (binary, cannot contain headers)
+.*\.png
+.*\.gif
+.*\.ico
+.*\.jpg
+
 # Examples pattern (legacy - keeping for compatibility)
 apache_burr-.*/burr/examples

--- a/examples/deployment/aws/terraform/tutorial.md
+++ b/examples/deployment/aws/terraform/tutorial.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 # Apache Burr AWS Tracking Infrastructure Tutorial
 
 This tutorial explains how to deploy Apache Burr tracking infrastructure on AWS using Terraform. All Terraform code lives in `examples/deployment/aws/terraform/`. It covers deployment with S3 only (polling mode), with S3 and SQS (event-driven mode), and local development without AWS.

--- a/scripts/apache_release.py
+++ b/scripts/apache_release.py
@@ -477,9 +477,26 @@ def _build_ui_artifacts() -> None:
     except Exception as e:
         _fail(f"Failed to copy build artifacts: {e}")
 
+    # Remove source maps (debug artifacts, not needed in wheel)
+    for map_file in glob.glob(os.path.join(ui_build_dir, "**", "*.map"), recursive=True):
+        os.remove(map_file)
+        print(f"    ✓ Removed source map: {os.path.basename(map_file)}")
+
     # Verify
     if not os.path.exists(ui_build_dir) or not os.listdir(ui_build_dir):
         _fail(f"UI build directory is empty: {ui_build_dir}")
+
+
+def _clean_wheel_excludes() -> None:
+    """Remove files that should not be in the wheel distribution."""
+    excludes = [
+        "burr/tracking/server/s3/deployment/terraform/.terraform.lock.hcl",
+        "burr/tracking/server/s3/deployment/terraform/.gitignore",
+    ]
+    for filepath in excludes:
+        if os.path.exists(filepath):
+            os.remove(filepath)
+            print(f"    ✓ Removed from wheel: {filepath}")
 
 
 def _prepare_wheel_contents() -> tuple[bool, bool, Optional[str]]:
@@ -550,6 +567,7 @@ def _build_wheel_from_current_dir(version: str, output_dir: str = "dist") -> str
     _build_ui_artifacts()
 
     _print_step(2, 3, "Preparing wheel contents")
+    _clean_wheel_excludes()
     copied, was_symlink, symlink_target = _prepare_wheel_contents()
 
     _print_step(3, 3, "Building wheel with flit")


### PR DESCRIPTION
## Summary
- Remove `.terraform.lock.hcl`, `.gitignore`, and source maps from wheel build (not runtime dependencies, saves ~15MB)
- Add `.github/` templates and image file extensions to `.rat-excludes`
- Add ASF header to `examples/deployment/aws/terraform/tutorial.md`

Addresses feedback from RC2 audit to ensure clean wheel contents and zero RAT false positives.

## Test plan
- [ ] Rebuild wheel and verify no `.terraform.lock.hcl`, `.gitignore`, or `*.map` files in contents
- [ ] Run Apache RAT on source tarball and confirm zero unapproved files