### PR TITLE
fix: use module logger instead of root logger in b_aiosqlite.py

### DIFF
--- a/burr/integrations/persisters/b_aiosqlite.py
+++ b/burr/integrations/persisters/b_aiosqlite.py
@@ -26,7 +26,7 @@ from burr.common.types import BaseCopyable
 from burr.core import State
 from burr.core.persistence import AsyncBaseStatePersister, PersistedStateData
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 try:
     from typing import Self


### PR DESCRIPTION
## Problem

In `burr/integrations/persisters/b_aiosqlite.py`, the logger is created using `logging.getLogger()` (no arguments), which returns the **root logger**. Every other persister module in the same package uses `logging.getLogger(__name__)` to create a properly scoped module logger.

Using the root logger causes log messages to bypass the module's namespace, making it harder to filter or configure logging for this specific module, and can lead to unexpected log output appearing in root logger handlers even when the module's logging is intended to be suppressed.

## Fix

Changed `logging.getLogger()` to `logging.getLogger(__name__)` for consistency with all other persister implementations:

```python
# Before
logger = logging.getLogger()

# After
logger = logging.getLogger(__name__)
```

This is a one-line fix. All other persisters already use this pattern:
- `b_pymongo.py` → `logging.getLogger(__name__)`
- `b_mongodb.py` → `logging.getLogger(__name__)`
- `b_redis.py` → `logging.getLogger(__name__)`
- `b_asyncpg.py` → `logging.getLogger(__name__)`
- `b_psycopg2.py` → `logging.getLogger(__name__)`
- `postgresql.py` → `logging.getLogger(__name__)`