### PR TITLE
fix: rename shadowed 'format' builtin in _render_graphviz

### DIFF
--- a/burr/core/graph.py
+++ b/burr/core/graph.py
@@ -95,20 +95,20 @@ def _render_graphviz(
 
     if output_file_path.suffix != "":
         # infer format from path; i.e., extract `svg` from the `.svg` suffix
-        format = output_file_path.suffix.partition(".")[-1]
+        fmt = output_file_path.suffix.partition(".")[-1]
     else:
-        format = "png"
+        fmt = "png"
 
     path_without_suffix = pathlib.Path(output_file_path.parent, output_file_path.stem)
     if write_dot or view:
         # `.render()` appends the `format` kwarg to the filename
         # i.e., we need to pass `/my/filepath` to generate `/my/filepath.png`
         # otherwise, passing `/my/filepath.png` will generate `/my/filepath.png.png`
-        graphviz_obj.render(path_without_suffix, format=format, view=view)
+        graphviz_obj.render(path_without_suffix, format=fmt, view=view)
     else:
         # `.pipe()` doesn't append the format to the filename, so we do it explicitly
-        pathlib.Path(f"{path_without_suffix}.{format}").write_bytes(
-            graphviz_obj.pipe(format=format)
+        pathlib.Path(f"{path_without_suffix}.{fmt}").write_bytes(
+            graphviz_obj.pipe(format=fmt)
         )
 
 


### PR DESCRIPTION
## Problem

In `burr/core/graph.py`, the function `_render_graphviz()` uses `format` as a local variable name (lines 98, 100). This shadows Python's built-in `format()` function, which can lead to confusion and potential bugs if the builtin is needed within the function's scope. Many linters (flake8 A001/A002, pylint W0622) flag this as a code smell.

## Fix

Renamed the local variable from `format` to `fmt` across all 5 occurrences within the function:

```python
# Before
format = output_file_path.suffix.partition(".")[-1]
format = "png"
graphviz_obj.render(path_without_suffix, format=format, view=view)
pathlib.Path(f"{path_without_suffix}.{format}").write_bytes(...)
graphviz_obj.pipe(format=format)

# After
fmt = output_file_path.suffix.partition(".")[-1]
fmt = "png"
graphviz_obj.render(path_without_suffix, format=fmt, view=view)
pathlib.Path(f"{path_without_suffix}.{fmt}").write_bytes(...)
graphviz_obj.pipe(format=fmt)
```

The keyword argument `format=` in calls to `graphviz_obj.render()` and `graphviz_obj.pipe()` is preserved as-is — only the local variable assignment and its usages are renamed. All behavior remains identical.