### PR TITLE
fix: correct validate_inputs error message when both missing and additional inputs exist

### DIFF
--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -243,16 +243,12 @@ class Function(abc.ABC):
         missing_inputs = required_inputs - given_inputs
         additional_inputs = given_inputs - required_inputs - optional_inputs
         if missing_inputs or additional_inputs:
-            raise ValueError(
-                f"Inputs to function {self} are invalid. "
-                + f"Missing the following inputs: {', '.join(missing_inputs)}."
-                if missing_inputs
-                else (
-                    "" f"Additional inputs: {','.join(additional_inputs)}."
-                    if additional_inputs
-                    else ""
-                )
-            )
+            parts = [f"Inputs to function {self} are invalid."]
+            if missing_inputs:
+                parts.append(f"Missing the following inputs: {', '.join(missing_inputs)}.")
+            if additional_inputs:
+                parts.append(f"Additional inputs: {', '.join(additional_inputs)}.")
+            raise ValueError(" ".join(parts))
 
     def is_async(self) -> bool:
         """Convenience method to check if the function is async or not.


### PR DESCRIPTION
## Problem

In `burr/core/action.py`, the `validate_inputs()` method had a bug in its error message construction due to Python's operator precedence in a nested ternary expression.

The original code:

```python
raise ValueError(
    f"Inputs to function {self} are invalid. "
    + f"Missing the following inputs: {', '.join(missing_inputs)}."
    if missing_inputs
    else (
        "" f"Additional inputs: {','.join(additional_inputs)}."
        if additional_inputs
        else ""
    )
)
```

Due to Python operator precedence, `if...else` (conditional expression) binds **lower** than `+`, so the expression is actually parsed as:

```python
(str1 + str2) if missing_inputs else (str3 if additional_inputs else "")
```

This causes two bugs:

1. **When both `missing_inputs` and `additional_inputs` are non-empty**: The `if missing_inputs` branch is taken, and only the missing inputs info is reported. The additional inputs info is silently dropped.

2. **When only `additional_inputs` is non-empty**: The error message is just `"Additional inputs: ..."` without the `"Inputs to function {self} are invalid."` prefix.

## Fix

Replaced the nested ternary with clear, independent conditionals that build error message parts:

```python
if missing_inputs or additional_inputs:
    parts = [f"Inputs to function {self} are invalid."]
    if missing_inputs:
        parts.append(f"Missing the following inputs: {', '.join(missing_inputs)}.")
    if additional_inputs:
        parts.append(f"Additional inputs: {', '.join(additional_inputs)}.")
    raise ValueError(" ".join(parts))
```

This ensures:
- The `"Inputs to function ... are invalid."` prefix is always present
- Missing inputs info is included when applicable
- Additional inputs info is included when applicable
- Both are included when both conditions are true
- Also fixed a minor inconsistency: `','.join` changed to `', '.join` for consistent spacing
