### PR TITLE
Emit standard sha512sum format in release checksums

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -129,9 +129,9 @@ gpg --verify apache-burr-${VERSION}-incubating-sdist.tar.gz.asc apache-burr-${VE
 gpg --verify apache_burr-${VERSION}-py3-none-any.whl.asc apache_burr-${VERSION}-py3-none-any.whl
 
 # 3. Verify all SHA512 checksums
-echo "$(cat apache-burr-${VERSION}-incubating-src.tar.gz.sha512)  apache-burr-${VERSION}-incubating-src.tar.gz" | sha512sum -c -
-echo "$(cat apache-burr-${VERSION}-incubating-sdist.tar.gz.sha512)  apache-burr-${VERSION}-incubating-sdist.tar.gz" | sha512sum -c -
-echo "$(cat apache_burr-${VERSION}-py3-none-any.whl.sha512)  apache_burr-${VERSION}-py3-none-any.whl" | sha512sum -c -
+sha512sum -c apache-burr-${VERSION}-incubating-src.tar.gz.sha512
+sha512sum -c apache-burr-${VERSION}-incubating-sdist.tar.gz.sha512
+sha512sum -c apache_burr-${VERSION}-py3-none-any.whl.sha512
 
 # 4. Extract the source archive
 tar -xzf apache-burr-${VERSION}-incubating-src.tar.gz

--- a/scripts/apache_release.py
+++ b/scripts/apache_release.py
@@ -246,14 +246,20 @@ def _check_git_working_tree() -> None:
 
 
 def _checksum_artifact(artifact_path: str) -> str:
-    """Create SHA512 checksum for artifact."""
+    """Create SHA512 checksum for artifact in the standard ``sha512sum`` layout.
+
+    The file is written as ``<digest>  <filename>\n`` so that voters can verify
+    with the standard ``sha512sum -c <file>.sha512`` recipe without having to
+    splice the filename in by hand.
+    """
     checksum_path = f"{artifact_path}.sha512"
     sha512_hash = hashlib.sha512()
     with open(artifact_path, "rb") as f:
         while chunk := f.read(65536):
             sha512_hash.update(chunk)
+    artifact_filename = os.path.basename(artifact_path)
     with open(checksum_path, "w", encoding="utf-8") as f:
-        f.write(f"{sha512_hash.hexdigest()}\n")
+        f.write(f"{sha512_hash.hexdigest()}  {artifact_filename}\n")
     print(f"  ✓ Created SHA512 checksum: {checksum_path}")
     return checksum_path
 


### PR DESCRIPTION
Surfaced during 0.42.0-incubating RC3 verification: the `.sha512` files shipped on dist.apache.org contain only the bare hex digest, so the standard `sha512sum -c file.sha512` recipe returns "no properly formatted checksum lines found". Voters either work around it with `echo "$(cat ${F}.sha512)  ${F}" | sha512sum -c -` (as the README currently does, see lines 132–134) or compare digests by hand.

## Change

- `scripts/apache_release.py::_checksum_artifact()` — emit the standard `<digest>  <filename>\n` layout that `sha512sum -c` and `shasum -c` both expect.
- `scripts/README.md` — drop the `echo "$(cat …)"` workaround in the verification workflow and use plain `sha512sum -c <file>.sha512`.

## Compatibility

Both checksum readers in the repo already use `.read().strip().split()[0]`:
- `scripts/verify_apache_artifacts.py:113`
- `scripts/apache_release.py::_verify_artifact_checksum` (line 310)

So they accept both the old bare-digest format and the new standard format — verification of existing RCs on dist.apache.org keeps working unchanged.

## Sanity test

```
$ python -c "from scripts.apache_release import _checksum_artifact; _checksum_artifact('artifact.tar.gz')"
$ cat artifact.tar.gz.sha512
e29ce…726b  artifact.tar.gz
$ sha512sum -c artifact.tar.gz.sha512
artifact.tar.gz: OK
```

## Vote thread

https://lists.apache.org/thread/bhcwnjpbx7vhnql48z7vc3njpgrx9qmj

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following the verification of 0.42.0-incubating RC3 on the IPMC vote thread.