### PR TITLE
chore: bump version to 0.42.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-burr"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
Released as 0.42.0-incubating today (May 9, 2026).

This is the version bump that the `v0.42.0-incubating-RC3` and `v0.42.0-incubating` tags point at, and that the released artifacts (now in `dist/release/incubator/burr/0.42.0/`) were built from.

Landing on main so future builds carry the correct version.

## References
- IPMC vote: https://lists.apache.org/thread/bhcwnjpbx7vhnql48z7vc3njpgrx9qmj
- PPMC vote: https://lists.apache.org/thread/t1ktvfyzq885qsylr9w97nwpttlf2w4v
- Released artifacts: https://dist.apache.org/repos/dist/release/incubator/burr/0.42.0/