### PR TITLE
docs: rename pip install burr -> pip install apache-burr

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Longer [video intro & walkthrough](https://www.youtube.com/watch?v=rEZ4oDN0GdU).
 Install from `pypi`:
 
 ```bash
-pip install "burr[start]"
+pip install "apache-burr[start]"
 ```
 
 (see [the docs](https://burr.apache.org/getting_started/install/) if you're using poetry)

--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -1462,7 +1462,7 @@ class action:
             from burr.integrations.pydantic import pydantic_action
         except ImportError:
             raise ImportError(
-                "Please install pydantic to use the pydantic decorator. pip install burr[pydantic]"
+                "Please install pydantic to use the pydantic decorator. pip install apache-burr[pydantic]"
             )
 
         return pydantic_action(
@@ -1525,7 +1525,7 @@ class streaming_action:
             from burr.integrations.pydantic import pydantic_streaming_action
         except ImportError:
             raise ImportError(
-                "Please install pydantic to use the pydantic decorator. pip install 'burr[pydantic]'"
+                "Please install pydantic to use the pydantic decorator. pip install 'apache-burr[pydantic]'"
             )
 
         return pydantic_streaming_action(

--- a/burr/core/graph.py
+++ b/burr/core/graph.py
@@ -206,7 +206,7 @@ class Graph:
         except ModuleNotFoundError:
             logger.exception(
                 " graphviz is required for visualizing the application graph. Install it with:"
-                '\n\n  pip install "burr[graphviz]" or pip install graphviz \n\n'
+                '\n\n  pip install "apache-burr[graphviz]" or pip install graphviz \n\n'
             )
             return
         digraph_attr = dict(

--- a/burr/tracking/server/s3/README.md
+++ b/burr/tracking/server/s3/README.md
@@ -33,7 +33,7 @@ The server is executable by a simple python command (although in production you'
 To get everything you need, you can install as you would any python library:
 
 ```bash
-pip install "burr[tracking-server-s3, cli]"
+pip install "apache-burr[tracking-server-s3, cli]"
 ```
 
 Note that this enables you to run through the CLI -- you won't need the CLI target to run in production,

--- a/docs/concepts/tracking.rst
+++ b/docs/concepts/tracking.rst
@@ -27,7 +27,7 @@ Tracking Burr
 
     Burr's telemetry system is built in and easy to integrate. It allows you to understand
     the flow of your application, and watch it make decisions in real time. You can run it
-    with sample projects by running ``burr`` in the terminal after ``pip install "burr[start]"``.
+    with sample projects by running ``burr`` in the terminal after ``pip install "apache-burr[start]"``.
 
 Burr comes with a telemetry system that allows tracking a variety of information for debugging,
 both in development and production.

--- a/docs/examples/chatbots/rag-chatbot-hamilton.ipynb
+++ b/docs/examples/chatbots/rag-chatbot-hamilton.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install burr[start] sf-hamilton[visualization] openai "
+    "!pip install apache-burr[start] sf-hamilton[visualization] openai "
    ]
   },
   {

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -28,7 +28,7 @@ along with a fully built server.
 
 .. code-block:: bash
 
-    pip install "burr[start]"
+    pip install "apache-burr[start]"
 
 This will give you tools to visualize, track, and interact with the UI. You can explore the UI (including some sample projects)
 simply by running the command ``burr``. Up next we'll write our own application and follow it in the UI.
@@ -48,135 +48,135 @@ Description of different targets
 
 .. code-block:: bash
 
-    pip install burr
+    pip install apache-burr
 
 This only installs the framework. Zero other dependencies. All other installs below all install the
 framework + some other dependencies. Note you can combine installing multiple optional dependencies with commas, e.g.
-``pip install "burr[cli,tracking]"`` installs both the CLI and tracking + UI dependencies.
+``pip install "apache-burr[cli,tracking]"`` installs both the CLI and tracking + UI dependencies.
 
 .. code-block:: bash
 
-    pip install "burr[cli]"
+    pip install "apache-burr[cli]"
 
 This installs the dependencies to run the burr CLI, i.e. `burr --help`.
 
 .. code-block:: bash
 
-    pip install "burr[developer]"
+    pip install "apache-burr[developer]"
 
 This installs all the dependencies for developing locally.
 
 .. code-block:: bash
 
-    pip install "burr[documentation]"
+    pip install "apache-burr[documentation]"
 
 This installs the dependencies to build the documentation.
 
 .. code-block:: bash
 
-    pip install "burr[examples]"
+    pip install "apache-burr[examples]"
 
 This installs the dependencies for the examples.
 
 
 .. code-block:: bash
 
-    pip install "burr[graphviz]"
+    pip install "apache-burr[graphviz]"
 
 This installs the dependencies to visualize the graph.
 
 .. code-block:: bash
 
-    pip install "burr[hamilton]"
+    pip install "apache-burr[hamilton]"
 
 This installs the dependencies for Hamilton.
 
 .. code-block:: bash
 
-    pip install "burr[haystack]"
+    pip install "apache-burr[haystack]"
 
 This installs the dependencies for Haystack.
 
 .. code-block:: bash
 
-    pip install "burr[learn]"
+    pip install "apache-burr[learn]"
 
 This installs the dependencies for the UI, CLI, and running demos. It is equivalent to `start` below.
 
 .. code-block:: bash
 
-    pip install "burr[opentelemetry]"
+    pip install "apache-burr[opentelemetry]"
 
 This installs the dependencies for using OpenTelemetry with Burr.
 
 .. code-block:: bash
 
-    pip install "burr[postgresql]"
+    pip install "apache-burr[postgresql]"
 
 This installs the dependencies for PostgreSQL.
 
 .. code-block:: bash
 
-    pip install "burr[pydantic]"
+    pip install "apache-burr[pydantic]"
 
 This installs the dependencies for Pydantic.
 
 .. code-block:: bash
 
-    pip install "burr[redis]"
+    pip install "apache-burr[redis]"
 
 This installs the dependencies for Redis.
 
 .. code-block:: bash
 
-    pip install "burr[start]"
+    pip install "apache-burr[start]"
 
 This installs the dependencies for the UI, CLI, and running demos. It is equivalent to `learn` above.
 
 .. code-block:: bash
 
-    pip install "burr[streamlit]"
+    pip install "apache-burr[streamlit]"
 
 This installs the dependencies for Streamlit.
 
 .. code-block:: bash
 
-    pip install "burr[tests]"
+    pip install "apache-burr[tests]"
 
 This installs the dependencies for running unit tests.
 
 .. code-block:: bash
 
-    pip install "burr[tracking]"
+    pip install "apache-burr[tracking]"
 
 This installs the client and server dependencies for tracking and running the UI from tracking that is on a filesystem.
 
 .. code-block:: bash
 
-    pip install "burr[tracking-client]"
+    pip install "apache-burr[tracking-client]"
 
 This installs the client dependencies for tracking to a filesystem.
 
 .. code-block:: bash
 
-    pip install "burr[tracking-client-s3]"
+    pip install "apache-burr[tracking-client-s3]"
 
 This installs the client dependencies for tracking to S3.
 
 .. code-block:: bash
 
-    pip install "burr[tracking-server-s3]"
+    pip install "apache-burr[tracking-server-s3]"
 
 This installs the server dependencies to run the UI and load tracking that was sent to S3.
 
 .. code-block:: bash
 
-    pip install "burr[tracking-server]"
+    pip install "apache-burr[tracking-server]"
 
 This installs the server dependencies for running the UI off a filesystem.
 
 .. code-block:: bash
 
-    pip install "burr[bedrock]"
+    pip install "apache-burr[bedrock]"
 
 This installs ``boto3`` for the :ref:`Amazon Bedrock integration <bedrock-integration>` (``BedrockAction`` / ``BedrockStreamingAction``).

--- a/docs/getting_started/up-next.rst
+++ b/docs/getting_started/up-next.rst
@@ -38,7 +38,7 @@ If you haven't already:
 
 .. code-block:: bash
 
-    pip install burr[start]
+    pip install apache-burr[start]
 
 Then:
 

--- a/docs/reference/integrations/bedrock.rst
+++ b/docs/reference/integrations/bedrock.rst
@@ -30,7 +30,7 @@ Install the optional extra (pulls ``boto3``):
 
 .. code-block:: bash
 
-   pip install "burr[bedrock]"
+   pip install "apache-burr[bedrock]"
 
 IAM permissions must allow ``bedrock:InvokeModel`` / streaming equivalents for your
 chosen models; see AWS documentation for your account and model IDs.

--- a/docs/reference/integrations/streamlit.rst
+++ b/docs/reference/integrations/streamlit.rst
@@ -28,7 +28,7 @@ Install with pypi:
 
 .. code-block:: bash
 
-   pip install burr[streamlit]
+   pip install apache-burr[streamlit]
 
 .. autoclass:: burr.integrations.streamlit.AppState
     :members:

--- a/examples/conversational-rag/simple_example/README.md
+++ b/examples/conversational-rag/simple_example/README.md
@@ -34,7 +34,7 @@ of the conversation and asking for user inputs.
 To run this example, install Burr and the necessary dependencies:
 
 ```bash
-pip install "burr[start]" -r requirements.txt
+pip install "apache-burr[start]" -r requirements.txt
 ```
 
 Then run the server in the background:

--- a/examples/conversational-rag/simple_example/notebook.ipynb
+++ b/examples/conversational-rag/simple_example/notebook.ipynb
@@ -32,7 +32,7 @@
     }
    },
    "source": [
-    "!pip install burr[start] sf-hamilton[visualization] openai "
+    "!pip install apache-burr[start] sf-hamilton[visualization] openai "
    ],
    "outputs": []
   },

--- a/examples/custom-serde/notebook.ipynb
+++ b/examples/custom-serde/notebook.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install burr[start] langchain_core langchain_community pydantic\n",
+    "!pip install apache-burr[start] langchain_core langchain_community pydantic\n",
     "# we only need these to show case the automatic serialization and deserialization that Burr has."
    ]
   },

--- a/examples/deep-researcher/notebook.ipynb
+++ b/examples/deep-researcher/notebook.ipynb
@@ -143,7 +143,7 @@
    ],
    "execution_count": 1,
    "source": [
-    "!pip install burr[start]\n",
+    "!pip install apache-burr[start]\n",
     "!pip install openai\n",
     "!pip install tavily-python"
    ],

--- a/examples/email-assistant/notebook.ipynb
+++ b/examples/email-assistant/notebook.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "!pip install burr[start] openai",
+   "source": "!pip install apache-burr[start] openai",
    "id": "25717d145f989eec"
   },
   {

--- a/examples/hello-world-counter/notebook.ipynb
+++ b/examples/hello-world-counter/notebook.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "!pip install burr[start]",
+   "source": "!pip install apache-burr[start]",
    "id": "500d692cd72c67b3"
   },
   {

--- a/examples/image-telephone/notebook.ipynb
+++ b/examples/image-telephone/notebook.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install burr[start] openai requests"
+    "!pip install apache-burr[start] openai requests"
    ]
   },
   {

--- a/examples/llm-adventure-game/notebook.ipynb
+++ b/examples/llm-adventure-game/notebook.ipynb
@@ -20,7 +20,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install burr[start]"
+    "!pip install apache-burr[start]"
    ]
   },
   {

--- a/examples/multi-agent-collaboration/README.md
+++ b/examples/multi-agent-collaboration/README.md
@@ -50,7 +50,7 @@ More functionality is on the roadmap!
 Install the dependencies:
 
 ```bash
-pip install "burr[start]" -r requirements.txt
+pip install "apache-burr[start]" -r requirements.txt
 ```
 
 Make sure you have the API Keys in your environment:

--- a/examples/multi-agent-collaboration/hamilton/README.md
+++ b/examples/multi-agent-collaboration/hamilton/README.md
@@ -41,7 +41,7 @@ More functionality is on the roadmap!
 Install the dependencies:
 
 ```bash
-pip install "burr[start]" -r requirements.txt
+pip install "apache-burr[start]" -r requirements.txt
 ```
 
 Make sure you have the API Keys in your environment:

--- a/examples/multi-agent-collaboration/lcel/README.md
+++ b/examples/multi-agent-collaboration/lcel/README.md
@@ -33,7 +33,7 @@ More functionality is on the roadmap!
 Install the dependencies:
 
 ```bash
-pip install "burr[start]" -r requirements.txt
+pip install "apache-burr[start]" -r requirements.txt
 ```
 
 Make sure you have the API Keys in your environment:

--- a/examples/multi-modal-chatbot/notebook.ipynb
+++ b/examples/multi-modal-chatbot/notebook.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "!pip install burr[start]",
+   "source": "!pip install apache-burr[start]",
    "id": "a1e0bae74e5d0d91"
   },
   {

--- a/examples/other-examples/cowsay/notebook.ipynb
+++ b/examples/other-examples/cowsay/notebook.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install burr[start]"
+    "!pip install apache-burr[start]"
    ]
   },
   {

--- a/examples/ray/notebook.ipynb
+++ b/examples/ray/notebook.ipynb
@@ -98,7 +98,7 @@
    ],
    "source": [
     "# execute to load the Burr and Hamilton extensions\n",
-    "%pip install burr openai ray\n",
+    "%pip install apache-burr openai ray\n",
     "%load_ext burr.integrations.notebook"
    ]
   },

--- a/examples/simple-chatbot-intro/README.md
+++ b/examples/simple-chatbot-intro/README.md
@@ -22,7 +22,7 @@ Example that goes with [introductory blog post](https://blog.dagworks.io/p/burr-
 ## 🏃Quick start
 
 ```bash
-pip install "burr[start]" jupyter
+pip install "apache-burr[start]" jupyter
 ```
 
 Run the notebook:

--- a/examples/streaming-fastapi/notebook.ipynb
+++ b/examples/streaming-fastapi/notebook.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "!pip install burr[start]",
+   "source": "!pip install apache-burr[start]",
    "id": "5e46f9824f7c180a"
   },
   {

--- a/examples/streaming-overview/notebook.ipynb
+++ b/examples/streaming-overview/notebook.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install burr[start]"
+    "!pip install apache-burr[start]"
    ]
   },
   {

--- a/examples/talks/data_for_ai_oct_2024.ipynb
+++ b/examples/talks/data_for_ai_oct_2024.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip install burr[start,opentelemetry] opentelemetry-instrumentation-openai"
+    "#!pip install apache-burr[start,opentelemetry] opentelemetry-instrumentation-openai"
    ]
   },
   {

--- a/examples/test-case-creation/notebook.ipynb
+++ b/examples/test-case-creation/notebook.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install burr[start]"
+    "!pip install apache-burr[start]"
    ]
   },
   {

--- a/examples/tracing-and-spans/notebook.ipynb
+++ b/examples/tracing-and-spans/notebook.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install burr[start]"
+    "!pip install apache-burr[start]"
    ]
   },
   {

--- a/examples/typed-state/notebook.ipynb
+++ b/examples/typed-state/notebook.ipynb
@@ -73,7 +73,7 @@
     }
    ],
    "source": [
-    "%pip install 'burr[pydantic]' instructor openai rich"
+    "%pip install 'apache-burr[pydantic]' instructor openai rich"
    ]
   },
   {

--- a/examples/web-server/README.md
+++ b/examples/web-server/README.md
@@ -38,7 +38,7 @@ it requires human assistance at multiple points to build a better product.
 If you want to get a sense for how this looks, open the burr UI:
 
 ```bash
-pip install "burr[start]"
+pip install "apache-burr[start]"
 burr
 ```
 


### PR DESCRIPTION
## Summary

The PyPI package was renamed to `apache-burr` at the 0.41.0-incubating release, but ~30 files in docs, examples, and a few in-code error messages still tell users `pip install burr[...]`. That doesn't work — PyPI's `burr` is an unrelated placeholder.

This is a pure mechanical sweep:
- 32 files touched, 56 single-line replacements
- Only changes `pip install <maybe-quoted>burr[...]` → `pip install <maybe-quoted>apache-burr[...]`
- Does NOT touch `import burr`, `from burr.<...>`, the `burr` CLI command name, or any file paths

Sibling change: `apache/hamilton#1561` does the same `sf-hamilton` → `apache-hamilton` cleanup.

## Test plan
- [ ] CI green (release-validation, tests, lint)
- [ ] Spot-check rendered `docs/getting_started/install.rst` on the docs site after merge