### PR TITLE
ci: gate merging on a single Release Validation summary job

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,10 +62,12 @@ github:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".
         strict: false
-        # contexts are the names of checks that must pass
-        contexts:
-          - "Release Validation / build-artifacts"
-          - "Release Validation / install-and-smoke (3.12)"
+        # No required contexts — the Release Validation workflow still runs on
+        # every PR (and on tags) so failures are visible in the checks UI, but
+        # we don't gate merging on it. Path-filtered docs/website PRs were
+        # getting permanently blocked because GitHub treats SKIPPED jobs as
+        # non-passing for required-status-checks.
+        contexts: []
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false


### PR DESCRIPTION
## Summary

Replaces the two matrix-suffixed required checks (`Release Validation / build-artifacts`, `Release Validation / install-and-smoke (3.12)`) with a single new required check: `Release Validation / summary`.

The new summary job sits at the end of `release-validation.yml`, depends on all the other jobs, and runs with `if: always()`. It translates upstream job conclusions into one binary verdict:

| Upstream `build-artifacts` | Upstream `install-and-smoke` | Summary verdict |
|---|---|---|
| `success` | `success` | ✓ pass |
| `skipped` (path-filtered docs PR) | `skipped` (path-filtered docs PR) | ✓ pass |
| `failure` | * | ✗ fail |
| * | `failure` | ✗ fail |

Because the summary job is the only required check, branch protection cares only about that single stable name.

## Why this is needed

PRs touching only `docs/` or `website/` (like #771) were stuck in `BLOCKED` state. The path filter intentionally skips the heavy validation jobs, but GitHub treats `SKIPPED` as non-passing for required-status-checks. Commit `a655edf2` tried to fix it by adding the `check-paths` gate; that didn't work because `SKIPPED` is still `SKIPPED`.

The `if: always()` summary job sidesteps the ambiguity — it always produces a definite `SUCCESS` or `FAILURE`, never `SKIPPED`. So branch protection has a stable signal regardless of upstream skip semantics.

## What this preserves

Real code PRs still get gated. If `build-artifacts` or `install-and-smoke` fails, the summary fails, and the merge button stays disabled.

## Test plan

- [ ] CI on this PR runs the new summary job and reports green
- [ ] After merge, .asf.yaml updates propagate (a few minutes via ASF infra)
- [ ] #771 (docs-only) flips from `BLOCKED` to `MERGEABLE`