### PR TITLE
ci: gate merging on a single Release Validation summary job

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,10 +62,13 @@ github:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".
         strict: false
-        # contexts are the names of checks that must pass
+        # The Release Validation workflow ends in a single "summary" job that
+        # runs with if: always() and translates upstream SUCCESS or SKIPPED
+        # into a definite SUCCESS, FAILURE into FAILURE. That gives us one
+        # stable required check name regardless of whether the upstream jobs
+        # ran (real code PR) or were path-filtered out (docs/website PR).
         contexts:
-          - "Release Validation / build-artifacts"
-          - "Release Validation / install-and-smoke (3.12)"
+          - "Release Validation / summary"
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -193,3 +193,33 @@ jobs:
           path: /tmp/burr-smoke-*
           retention-days: 7
           if-no-files-found: ignore
+
+  # Single stable required-check name. Always runs (if: always()) so it produces
+  # a definite SUCCESS or FAILURE — never SKIPPED. Branch protection in
+  # .asf.yaml requires this context, not the underlying jobs, so path-filtered
+  # docs/website PRs (where the upstream jobs are skipped) still go green here.
+  summary:
+    name: "Release Validation / summary"
+    needs: [check-paths, build-artifacts, install-and-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verdict
+        env:
+          CHECK_PATHS: ${{ needs.check-paths.result }}
+          BUILD_ARTIFACTS: ${{ needs.build-artifacts.result }}
+          INSTALL_AND_SMOKE: ${{ needs.install-and-smoke.result }}
+        run: |
+          echo "check-paths:       $CHECK_PATHS"
+          echo "build-artifacts:   $BUILD_ARTIFACTS"
+          echo "install-and-smoke: $INSTALL_AND_SMOKE"
+          # Pass if every needed job is success or skipped; fail if any
+          # failed or was cancelled.
+          for r in "$CHECK_PATHS" "$BUILD_ARTIFACTS" "$INSTALL_AND_SMOKE"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::Release Validation failed (one or more jobs not success/skipped)"; exit 1 ;;
+            esac
+          done
+          echo "Release Validation: all upstream jobs success or skipped."

--- a/burr/core/graph.py
+++ b/burr/core/graph.py
@@ -107,9 +107,7 @@ def _render_graphviz(
         graphviz_obj.render(path_without_suffix, format=fmt, view=view)
     else:
         # `.pipe()` doesn't append the format to the filename, so we do it explicitly
-        pathlib.Path(f"{path_without_suffix}.{fmt}").write_bytes(
-            graphviz_obj.pipe(format=fmt)
-        )
+        pathlib.Path(f"{path_without_suffix}.{fmt}").write_bytes(graphviz_obj.pipe(format=fmt))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Summary

Replaces the two matrix-suffixed required checks (`Release Validation / build-artifacts`, `Release Validation / install-and-smoke (3.12)`) with a single new required check: `Release Validation / summary`.

The new summary job sits at the end of `release-validation.yml`, depends on all the other jobs, and runs with `if: always()`. It translates upstream job conclusions into one binary verdict:

| Upstream `build-artifacts` | Upstream `install-and-smoke` | Summary verdict |
|---|---|---|
| `success` | `success` | ✓ pass |
| `skipped` (path-filtered docs PR) | `skipped` (path-filtered docs PR) | ✓ pass |
| `failure` | * | ✗ fail |
| * | `failure` | ✗ fail |

Because the summary job is the only required check, branch protection cares only about that single stable name.

## Why this is needed

PRs touching only `docs/` or `website/` (like #771) were stuck in `BLOCKED` state. The path filter intentionally skips the heavy validation jobs, but GitHub treats `SKIPPED` as non-passing for required-status-checks. Commit `a655edf2` tried to fix it by adding the `check-paths` gate; that didn't work because `SKIPPED` is still `SKIPPED`.

The `if: always()` summary job sidesteps the ambiguity — it always produces a definite `SUCCESS` or `FAILURE`, never `SKIPPED`. So branch protection has a stable signal regardless of upstream skip semantics.

## What this preserves

Real code PRs still get gated. If `build-artifacts` or `install-and-smoke` fails, the summary fails, and the merge button stays disabled.

(Reopens the work from #774, which GitHub wouldn't allow to be reopened after the force-push.)

## Test plan

- [ ] CI on this PR runs the new summary job and reports green
- [ ] After merge, .asf.yaml updates propagate (a few minutes via ASF infra)
- [ ] #771 (docs-only) flips from \`BLOCKED\` to \`MERGEABLE\`