### PR TITLE
docs: fix stale dagworks-inc/burr URLs and bracketed-extras installs

### DIFF
--- a/burr/tracking/server/s3/deployment/Dockerfile
+++ b/burr/tracking/server/s3/deployment/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update && apt-get install -y \
 
 # Install the dependencies
 # TODO -- use the right version
-#RUN pip install "git+https://github.com/dagworks-inc/burr.git@tracker-s3#egg=burr[tracking-server-s3]"
-RUN pip install "burr[tracking-server-s3]>=0.29.0"
+#RUN pip install "git+https://github.com/apache/burr.git@tracker-s3#egg=apache-burr[tracking-server-s3]"
+RUN pip install "apache-burr[tracking-server-s3]>=0.29.0"
 
 # Copy the nginx config file
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -38,7 +38,7 @@ Instead, please install manually using the following command:
 
 .. code-block:: bash
 
-    poetry add loguru "burr[tracking-client,tracking-server,streamlit,graphviz,hamilton]"
+    poetry add loguru "apache-burr[tracking-client,tracking-server,streamlit,graphviz,hamilton]"
 
 This is just the kitchen sink for getting started -- remember, burr is dependency-free/pure python!
 

--- a/examples/conversational-rag/graph_db_example/notebook.ipynb
+++ b/examples/conversational-rag/graph_db_example/notebook.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "source": [
     "# install requirements\n",
-    "!pip install falkordb openai burr[graphviz] "
+    "!pip install falkordb openai apache-burr[graphviz] "
    ],
    "outputs": []
   },

--- a/examples/conversational-rag/simple_example/README.md
+++ b/examples/conversational-rag/simple_example/README.md
@@ -56,7 +56,7 @@ You'll then have a text terminal where you can interact. Type exit to stop.
 ![Application Image](statemachine.png)
 
 # Video Walkthrough via Notebook
-Open the notebook <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/conversational-rag/simple_example/notebook.ipynb">
+Open the notebook <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/conversational-rag/simple_example/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/custom-serde/README.md
+++ b/examples/custom-serde/README.md
@@ -38,7 +38,7 @@ pip install jupyter
 jupyter notebook
 ``
 
-and running the notebook. Or <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/custom-serde/notebook.ipynb">
+and running the notebook. Or <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/custom-serde/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>.
 

--- a/examples/email-assistant/README.md
+++ b/examples/email-assistant/README.md
@@ -48,7 +48,7 @@ Note we will be adding two things to this demo:
 1. An integration with the burr web app
 2. a standalone server example with a walkthrough
 
-Open the notebook <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/email-assistant/notebook.ipynb">
+Open the notebook <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/email-assistant/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/hamilton-integration/notebook.ipynb
+++ b/examples/hamilton-integration/notebook.ipynb
@@ -24,14 +24,14 @@
    "source": [
     "# execute this cell to install dependencies in the current environment\n",
     "# useful when using Google Colab notebooks\n",
-    "%pip install sf-hamilton[visualization] requests openai lancedb burr[start,opentelemetry] pydantic pyarrow opentelemetry-instrumentation-openai opentelemetry-instrumentation-lancedb"
+    "%pip install sf-hamilton[visualization] requests openai lancedb apache-burr[start,opentelemetry] pydantic pyarrow opentelemetry-instrumentation-openai opentelemetry-instrumentation-lancedb"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Use the 2-layer approach for a maintainable RAG system [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/hamilton-integration/notebook.ipynb) [![GitHub badge](https://img.shields.io/badge/github-view_source-2b3137?logo=github)](https://github.com/apache/burr/blob/main/examples/hamilton-integration/notebook.ipynb)\n",
+    "# Use the 2-layer approach for a maintainable RAG system [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/apache/burr/blob/main/examples/hamilton-integration/notebook.ipynb) [![GitHub badge](https://img.shields.io/badge/github-view_source-2b3137?logo=github)](https://github.com/apache/burr/blob/main/examples/hamilton-integration/notebook.ipynb)\n",
     "\n",
     "Ready-made solutions can get you started with GenAI, but building reliable product features with retrieval augmented generation (RAG) and LLM agents inevitably required custom code. This post shares the 2-layer approach to build a maintainable RAG application that will evolve with your needs. To illustrate these ideas, we will show how a typical RAG project might evolve.\n",
     "\n",

--- a/examples/hello-world-counter/README.md
+++ b/examples/hello-world-counter/README.md
@@ -26,7 +26,7 @@ We have three files:
 - [application.py](application.py) -- This contains a mainline to run the counter as well as a function to export the counter (for later use)
 - [requirements.txt](requirements.txt) -- Just the requirements. All this needs is Burr/Streamlit
 - [streamlit_app.py](streamlit_app.py) -- This contains a simple Streamlit app to interact with the counter.
-- [notebook.ipynb](notebook.ipynb) -- A notebook that shows the counter app too. Open the notebook <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/hello-world-counter/notebook.ipynb">
+- [notebook.ipynb](notebook.ipynb) -- A notebook that shows the counter app too. Open the notebook <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/hello-world-counter/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/image-telephone/README.md
+++ b/examples/image-telephone/README.md
@@ -44,7 +44,7 @@ We recommend starting with the notebook.
 
 ### notebook.ipynb
 You can use [notebook.ipynb](./notebook.ipynb) to run things. Or
-<a target="_blank" href="https://colab.research.google.com/github/DAGWorks-Inc/burr/blob/main/examples/image-telephone/notebook.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/image-telephone/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/llm-adventure-game/README.md
+++ b/examples/llm-adventure-game/README.md
@@ -26,7 +26,7 @@ How to run:
 OPENAI_API_KEY=<your key> python application.py
 ```
 
-Open the notebook <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/llm-adventure-game/notebook.ipynb">
+Open the notebook <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/llm-adventure-game/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/multi-agent-collaboration/README.md
+++ b/examples/multi-agent-collaboration/README.md
@@ -64,7 +64,7 @@ export TAVILY_API_KEY=YOUR_KEY
 To run the example, you can do:
 
 Run the notebook:
-<a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/multi-agent-collaboration/hamilton/notebook.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/multi-agent-collaboration/hamilton/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
@@ -77,7 +77,7 @@ Application run:
 or
 
 Run the notebook:
-<a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/multi-agent-collaboration/lcel/notebook.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/multi-agent-collaboration/lcel/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/multi-agent-collaboration/hamilton/README.md
+++ b/examples/multi-agent-collaboration/hamilton/README.md
@@ -52,7 +52,7 @@ export TAVILY_API_KEY=YOUR_KEY
 ```
 
 Run the notebook:
-<a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/multi-agent-collaboration/hamilton/notebook.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/multi-agent-collaboration/hamilton/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 or do it manually:

--- a/examples/multi-agent-collaboration/hamilton/notebook.ipynb
+++ b/examples/multi-agent-collaboration/hamilton/notebook.ipynb
@@ -43,7 +43,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install -U burr[start] langchain-community langchain-core langchain-experimental openai sf-hamilton[visualization]"
+    "# %pip install -U apache-burr[start] langchain-community langchain-core langchain-experimental openai sf-hamilton[visualization]"
    ]
   },
   {

--- a/examples/multi-agent-collaboration/lcel/README.md
+++ b/examples/multi-agent-collaboration/lcel/README.md
@@ -44,7 +44,7 @@ export TAVILY_API_KEY=YOUR_KEY
 ```
 
 Run the notebook:
-<a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/multi-agent-collaboration/lcel/notebook.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/multi-agent-collaboration/lcel/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 or do it manually:

--- a/examples/multi-agent-collaboration/lcel/notebook.ipynb
+++ b/examples/multi-agent-collaboration/lcel/notebook.ipynb
@@ -42,7 +42,7 @@
     }
    },
    "source": [
-    "# %pip install -U burr[start] langchain-community langchain-core langchain-experimental openai"
+    "# %pip install -U apache-burr[start] langchain-community langchain-core langchain-experimental openai"
    ],
    "outputs": []
   },

--- a/examples/multi-modal-chatbot/README.md
+++ b/examples/multi-modal-chatbot/README.md
@@ -45,7 +45,7 @@ We have a few files:
 - [application.py](application.py) -- This contains a mainline to generate the graph portrayal.
 - [requirements.txt](requirements.txt) -- Just the requirements. All this needs is Burr/Streamlit/openai
 - [simple_streamlit_app.py](simple_streamlit_app.py) -- This contains a more sophisticated Streamlit app to interact with.
-- [notebook.ipynb](notebook.ipynb) -- A notebook that helps exercise things. <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/multi-modal-chatbot/notebook.ipynb">
+- [notebook.ipynb](notebook.ipynb) -- A notebook that helps exercise things. <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/multi-modal-chatbot/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 - [streamlit_app.py](streamlit_app.py) -- This contains a simple Streamlit app to interact with that is more

--- a/examples/opentelemetry/notebook.ipynb
+++ b/examples/opentelemetry/notebook.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install \"burr[start]\"\n",
+    "!pip install \"apache-burr[start]\"\n",
     "!pip install opentelemetry-instrumentation-openai"
    ]
   },

--- a/examples/other-examples/cowsay/README.md
+++ b/examples/other-examples/cowsay/README.md
@@ -26,7 +26,7 @@ We have three files:
 - [application.py](application.py) -- This contains a mainline to run the cowsay app as well as a function to export the app (for later use)
 - [requirements.txt](requirements.txt) -- Just the requirements. All this needs is Burr/Streamlit/cowsay
 - [streamlit_app.py](streamlit_app.py) -- This contains a simple Streamlit app to interact with the cow
-- [notebook.ipynb](notebook.ipynb) -- A notebook that helps show things. <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/other-examples/cowsay/notebook.ipynb">
+- [notebook.ipynb](notebook.ipynb) -- A notebook that helps show things. <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/other-examples/cowsay/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/parallelism/README.md
+++ b/examples/parallelism/README.md
@@ -21,7 +21,7 @@
 
 In this example we go over Burr's parallelism capabilities. It is based on the documentation (https://burr.apache.org/concepts/parallelism/), demonstrating the `MapStates` capabilities.
 
-See [the notebook](./notebook.ipynb) for the full example. Or <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/parallelism/notebook.ipynb">
+See [the notebook](./notebook.ipynb) for the full example. Or <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/parallelism/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/examples/parallelism/notebook.ipynb
+++ b/examples/parallelism/notebook.ipynb
@@ -13,7 +13,7 @@
    "id": "f4b744ec-ce8d-4e6b-b818-d86f6a869028",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/parallelism/notebook.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/apache/burr/blob/main/examples/parallelism/notebook.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a> \n",
     "or <a target=\"_blank\" href=\"https://www.github.com/apache/burr/tree/main/examples/parallelism/notebook.ipynb\">view source</a>\n",
@@ -29,7 +29,7 @@
    "outputs": [],
    "source": [
     "# install some dependencies and a few more\n",
-    "%pip install \"burr[start,opentelemetry]\" opentelemetry-instrumentation-openai openai anthropic"
+    "%pip install \"apache-burr[start,opentelemetry]\" opentelemetry-instrumentation-openai openai anthropic"
    ]
   },
   {

--- a/examples/simple-chatbot-intro/README.md
+++ b/examples/simple-chatbot-intro/README.md
@@ -31,6 +31,6 @@ Run the notebook:
 jupyter notebook
 ```
 
-Then open `notebook.ipynb` and run the cells. Or <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/simple-chatbot-intro/notebook.ipynb">
+Then open `notebook.ipynb` and run the cells. Or <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/simple-chatbot-intro/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>

--- a/examples/simple-chatbot-intro/notebook.ipynb
+++ b/examples/simple-chatbot-intro/notebook.ipynb
@@ -25,7 +25,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install \"burr[start]\""
+    "!pip install \"apache-burr[start]\""
    ]
   },
   {

--- a/examples/streaming-overview/README.md
+++ b/examples/streaming-overview/README.md
@@ -38,6 +38,6 @@ which demonstrates how to use streaming async. We have not hooked this up
 to a streamlit application yet, but that should be trivial.
 
 ## Notebook
-The notebook also shows how things work. <a target="_blank" href="https://colab.research.google.com/github/dagworks-inc/burr/blob/main/examples/streaming-overview/notebook.ipynb">
+The notebook also shows how things work. <a target="_blank" href="https://colab.research.google.com/github/apache/burr/blob/main/examples/streaming-overview/notebook.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>

--- a/examples/tracing-and-spans/burr_otel_demo.ipynb
+++ b/examples/tracing-and-spans/burr_otel_demo.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "# install libs if you need them\n",
-    "!pip install \"burr[start]\" openai opentelemetry-instrumentation-openai"
+    "!pip install \"apache-burr[start]\" openai opentelemetry-instrumentation-openai"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Two follow-up cleanups the original rename PR #772 missed.

### 1. Stale `dagworks-inc/burr` URLs (17 swaps)

Mostly Colab links in example READMEs, plus a commented git URL in `burr/tracking/server/s3/deployment/Dockerfile`. These all 404 now that the repo lives at `apache/burr`. Replaced (case-insensitive) with `apache/burr`.

### 2. Bracketed-extras install commands the regex missed (11 swaps)

PR #772 caught `pip install burr` / `pip install "burr"` cleanly, but missed `pip install "burr[extras]"` in JSON-escaped notebook cells (`\"burr[start]\"`) and in `poetry add ... "burr[...]"`. Fixed in 9 notebooks, the Dockerfile, and `docs/getting_started/install.rst:41`.

### Scope guardrails

- The `burr[` rename only fires on lines containing `pip install` or `poetry add` — won't touch real Python code like `state["foo"]` or `burr.core` imports.
- The `dagworks-inc/burr` rename only matches that exact substring (case-insensitive).
- No code changes — just docs/notebooks/Dockerfile string swaps.

## Test plan
- [ ] CI green (release-validation, tests, lint)
- [ ] Spot-check a Colab link from one of the modified READMEs resolves to a Colab session