### PR TITLE
fix: use aware UTC for S3 log partitions

### DIFF
--- a/burr/tracking/s3client.py
+++ b/burr/tracking/s3client.py
@@ -204,7 +204,7 @@ class S3TrackingClient(SyncTrackingClient):
         self.stream_state: Dict[StateKey, StreamState] = dict()
 
     def _get_time_partition(self):
-        time = datetime.datetime.utcnow().isoformat()
+        time = datetime.datetime.now(datetime.UTC).isoformat()
         return [time[:4], time[5:7], time[8:10], time[11:13], time[14:]]
 
     def get_prefix(self):


### PR DESCRIPTION
Problem: S3TrackingClient._get_time_partition() used datetime.datetime.utcnow(), which is deprecated and returns a naive UTC timestamp.

Before / after: before, S3 log partition keys were derived from a naive UTC timestamp. After, they are derived from datetime.datetime.now(datetime.UTC), preserving UTC partitioning while avoiding the deprecated API.

Verification: python -m py_compile burr\tracking\s3client.py