### PR TITLE
add burr-redirect package for legacy 'burr' PyPI name

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -77,3 +77,8 @@
 **/*.gif
 **/*.ico
 **/*.jpg
+
+# burr-redirect: non-ASF PyPI redirect package, not part of the ASF source release.
+# The directory carries ASF-licensed templates but is not voted on as part of
+# any apache-burr release artifact.
+burr-redirect/**

--- a/burr-redirect/.gitignore
+++ b/burr-redirect/.gitignore
@@ -1,0 +1,4 @@
+pyproject.toml
+dist/
+build/
+*.egg-info/

--- a/burr-redirect/README.md
+++ b/burr-redirect/README.md
@@ -1,0 +1,44 @@
+<!--
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+-->
+
+# burr has moved to apache-burr
+
+This package is a redirect. Burr is now developed under the Apache
+Software Foundation as **Apache Burr (incubating)**.
+
+## Migration
+
+Replace `burr` with `apache-burr` in your dependencies:
+
+```bash
+pip install apache-burr
+```
+
+Extras carry over identically (`apache-burr[start]`, `apache-burr[tracking-server]`,
+etc.). The Python import path is unchanged — `from burr.core import ...`
+keeps working — because installing `apache-burr` installs the same `burr`
+Python module.
+
+For documentation and getting started, see:
+- https://burr.apache.org/
+- https://github.com/apache/burr
+
+This `burr` package on PyPI exists to keep `pip install burr` working for
+users on muscle memory or pinned dependencies. It contains no source code;
+it simply pins `apache-burr` of the matching version.

--- a/burr-redirect/build.sh
+++ b/burr-redirect/build.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Builds the burr redirect package for a given version.
+#
+# Usage:
+#   ./build.sh <version>
+#   ./build.sh 0.42.0
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.42.0"
+    exit 1
+fi
+
+VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Building burr redirect package for version ${VERSION}..."
+
+# Stamp version into pyproject.toml from template
+sed "s/VERSION/${VERSION}/g" "${SCRIPT_DIR}/pyproject.toml.template" > "${SCRIPT_DIR}/pyproject.toml"
+
+# Clean previous build
+rm -rf "${SCRIPT_DIR}/dist" "${SCRIPT_DIR}/build" "${SCRIPT_DIR}"/*.egg-info
+
+# Build
+cd "${SCRIPT_DIR}"
+python -m build
+
+# Validate
+twine check dist/*
+
+echo ""
+echo "Build complete. Artifacts:"
+ls -la dist/
+echo ""
+echo "To upload to TestPyPI (recommended first):"
+echo "  twine upload --repository testpypi dist/burr-${VERSION}*"
+echo ""
+echo "To verify from TestPyPI (note --extra-index-url so apache-burr resolves from real PyPI):"
+echo "  pip install --index-url https://test.pypi.org/simple/ \\"
+echo "    --extra-index-url https://pypi.org/simple/ burr==${VERSION}"
+echo ""
+echo "To upload to PyPI (after TestPyPI verification):"
+echo "  twine upload dist/burr-${VERSION}*"

--- a/burr-redirect/pyproject.toml.template
+++ b/burr-redirect/pyproject.toml.template
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "burr"
+version = "VERSION"
+description = "This package has moved to apache-burr. Install apache-burr instead."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+dependencies = ["apache-burr==VERSION"]
+
+[project.optional-dependencies]
+aiosqlite = ["apache-burr[aiosqlite]==VERSION"]
+asyncpg = ["apache-burr[asyncpg]==VERSION"]
+bedrock = ["apache-burr[bedrock]==VERSION"]
+cli = ["apache-burr[cli]==VERSION"]
+developer = ["apache-burr[developer]==VERSION"]
+documentation = ["apache-burr[documentation]==VERSION"]
+examples = ["apache-burr[examples]==VERSION"]
+graphviz = ["apache-burr[graphviz]==VERSION"]
+hamilton = ["apache-burr[hamilton]==VERSION"]
+haystack = ["apache-burr[haystack]==VERSION"]
+inappexamples = ["apache-burr[inappexamples]==VERSION"]
+learn = ["apache-burr[learn]==VERSION"]
+opentelemetry = ["apache-burr[opentelemetry]==VERSION"]
+postgresql = ["apache-burr[postgresql]==VERSION"]
+psycopg2 = ["apache-burr[psycopg2]==VERSION"]
+pydantic = ["apache-burr[pydantic]==VERSION"]
+pymongo = ["apache-burr[pymongo]==VERSION"]
+ray = ["apache-burr[ray]==VERSION"]
+redis = ["apache-burr[redis]==VERSION"]
+release = ["apache-burr[release]==VERSION"]
+start = ["apache-burr[start]==VERSION"]
+streamlit = ["apache-burr[streamlit]==VERSION"]
+tests = ["apache-burr[tests]==VERSION"]
+tracking = ["apache-burr[tracking]==VERSION"]
+tracking-client = ["apache-burr[tracking-client]==VERSION"]
+tracking-client-s3 = ["apache-burr[tracking-client-s3]==VERSION"]
+tracking-server = ["apache-burr[tracking-server]==VERSION"]
+tracking-server-s3 = ["apache-burr[tracking-server-s3]==VERSION"]
+
+[project.urls]
+Homepage = "https://burr.apache.org/"
+Documentation = "https://burr.apache.org/docs"
+Repository = "https://github.com/apache/burr"
+"Bug Tracker" = "https://github.com/apache/burr/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,8 @@ include = [
   "examples/hello-world-counter/**",
 ]
 exclude = [
+  # burr-redirect: non-ASF PyPI redirect package, not part of the ASF source release.
+  "burr-redirect/**",
   "telemetry/ui/node_modules/**",
   "telemetry/ui/build/**",
   "telemetry/ui/dist/**",


### PR DESCRIPTION
## Summary

Mirrors the [Hamilton `sf-hamilton-redirect/`](https://github.com/apache/hamilton/tree/main/sf-hamilton-redirect) pattern. Adds a thin metadata-only `burr` wheel that just pins `apache-burr==<version>` (plus every extra), so users on `pip install burr` (or `pip install burr[start]`, etc.) keep working and get the current `apache-burr` release transitively.

The legacy `burr` PyPI listing is currently at `0.40.2` (pre-Apache). Without this redirect, anyone with `burr` in their requirements never sees `apache-burr` updates and is stuck on a year-old codebase.

## What this PR adds

- `burr-redirect/pyproject.toml.template` — setuptools-based, `name = "burr"`, `dependencies = ["apache-burr==VERSION"]`, all 28 extras mirrored.
- `burr-redirect/build.sh` — stamps `VERSION` into the template, builds wheel + sdist, runs `twine check`, prints TestPyPI and PyPI upload commands.
- `burr-redirect/README.md` — "this package has moved" note, points users at `apache-burr`.
- `burr-redirect/.gitignore` — ignores generated `pyproject.toml`, `dist/`, `build/`, `*.egg-info/`.

## Excludes (so this stays out of ASF artifacts)

- `.rat-excludes`: `burr-redirect/**` so Apache RAT does not scan the metadata-only redirect package.
- `pyproject.toml`: `burr-redirect/**` added to `[tool.flit.sdist].exclude` so the redirect package is **not** bundled into the `apache-burr` source tarball. The redirect is a non-ASF artifact and must not appear in any IPMC-voted release.

## What this PR does NOT do

- Does not build, sign, or upload any release artifact.
- Does not change anything about `apache-burr`'s release pipeline.
- The legacy `burr` 0.42.0 wheel is built and uploaded **manually** after `apache-burr` 0.42.0 is live on PyPI, so the `==` pin resolves. The build.sh output enumerates TestPyPI and PyPI commands for that step.

## Local verification (already done)

```
cd burr-redirect && ./build.sh 0.42.0
# → builds dist/burr-0.42.0-py3-none-any.whl + dist/burr-0.42.0.tar.gz
# → twine check: both PASSED
# → wheel is 4 files, metadata only (no source)
# → all 28 extras present, exact apache-burr==0.42.0 pin
```

## Test plan

- [ ] CI green (release-validation, tests, lint) — the redirect dir is excluded from RAT and from `apache-burr`'s flit sdist, so should be a no-op for those jobs
- [ ] After merge: maintainer uploads `burr 0.42.0` to TestPyPI first (verifying with `--extra-index-url https://pypi.org/simple/` so `apache-burr` resolves), then to real PyPI