### PR TITLE
docs(deployments): add Burr UI on AWS deployment example (#391)

### DIFF
--- a/docs/examples/deployment/burr-ui-aws.rst
+++ b/docs/examples/deployment/burr-ui-aws.rst
@@ -1,0 +1,62 @@
+..
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+
+.. _burr-ui-aws-deployment:
+
+==============================
+Burr UI on AWS (Private VPC)
+==============================
+
+Deploy the Burr tracking UI server in a private VPC, reading from an existing S3 tracking bucket.
+Access is via AWS SSM Session Manager port forwarding.
+
+See the full example:
+
+* Source: `GitHub <https://github.com/apache/burr/tree/main/examples/deployment/aws/burr-ui>`_
+* ``examples/deployment/aws/burr-ui/README.md``
+
+-----------
+Quick Start
+-----------
+
+.. code-block:: bash
+
+    cd examples/deployment/aws/burr-ui/terraform
+    terraform init
+    terraform apply -var="s3_bucket_name=my-tracking-bucket"
+
+--------------------------
+Access the Private UI
+--------------------------
+
+.. code-block:: bash
+
+    INSTANCE_ID=$(terraform output -raw instance_id)
+    aws ssm start-session --target $INSTANCE_ID \
+      --document-name AWS-StartPortForwardingSession \
+      --parameters '{"portNumber":["7241"],"localPortNumber":["7241"]}'
+
+Then open http://localhost:7241.
+
+--------------
+Related Guides
+--------------
+
+* :ref:`S3 Tracking on AWS <s3-tracking-aws>`
+* :ref:`AWS Deployment overview <aws-deployment-example>`

--- a/docs/examples/deployment/index.rst
+++ b/docs/examples/deployment/index.rst
@@ -41,3 +41,4 @@ have an example that would add to this guide. We have created a variety of issue
     infrastructure
     monitoring
     aws
+    burr-ui-aws

--- a/examples/deployment/aws/burr-ui/Dockerfile
+++ b/examples/deployment/aws/burr-ui/Dockerfile
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 7241
+
+# The S3 bucket is configured via environment variable at runtime
+CMD ["burr", "--no-open", "--host", "0.0.0.0"]

--- a/examples/deployment/aws/burr-ui/README.md
+++ b/examples/deployment/aws/burr-ui/README.md
@@ -1,0 +1,147 @@
+<!--
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+-->
+
+# Deploy Burr UI on AWS (Private VPC, S3 Backend)
+
+Deploy the Burr tracking UI server in a private VPC on AWS, reading tracking data from
+an existing S3 bucket. Access is via AWS SSM Session Manager port forwarding — no public
+IP, no open inbound ports.
+
+## Overview
+
+This deploys a single-tenant Burr UI server that:
+
+- Runs in a private subnet inside a dedicated VPC
+- Reads and indexes tracking logs from your existing S3 bucket
+- Is accessible only via SSM port forwarding (no public internet exposure)
+- Uses a single EC2 instance (not horizontally scaled — by design)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ VPC (10.0.0.0/16)                                       │
+│                                                         │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │ Private Subnet                                  │    │
+│  │                                                 │    │
+│  │  ┌──────────────────────────┐                   │    │
+│  │  │ EC2 (t3.small)           │                   │    │
+│  │  │ - burr --no-open         │                   │    │
+│  │  │ - port 7241              │                   │    │
+│  │  │ - BURR_S3_BUCKET=...     │──── reads ──── S3 │    │
+│  │  └──────────────────────────┘                   │    │
+│  └─────────────────────────────────────────────────┘    │
+│                                                         │
+│  SSM VPC Endpoints (ssm, ssmmessages, ec2messages)      │
+│  NAT Gateway (outbound for pip install)                 │
+└─────────────────────────────────────────────────────────┘
+         │
+         │ SSM port-forward (your laptop)
+         ▼
+   http://localhost:7241
+```
+
+## Prerequisites
+
+- AWS CLI v2 configured with credentials
+- [AWS Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed
+- Terraform >= 1.5
+- An existing S3 bucket with Burr tracking data (written by `S3TrackingClient`)
+
+## Configure
+
+```bash
+cd examples/deployment/aws/burr-ui/terraform
+cp environments/dev.tfvars my.tfvars
+```
+
+Edit `my.tfvars` and set:
+- `s3_bucket_name` — your existing Burr tracking bucket name (required)
+- `aws_region` — the region where your bucket lives (default: us-east-1)
+
+## Deploy
+
+```bash
+terraform init
+terraform apply -var-file=my.tfvars
+```
+
+Wait 2-3 minutes for the instance to boot, install Burr, and start indexing.
+
+## Access the Private UI
+
+Use SSM port forwarding (no SSH key needed, no open ports):
+
+```bash
+# Get the instance ID from Terraform output
+INSTANCE_ID=$(terraform output -raw instance_id)
+
+# Start the port forward
+aws ssm start-session --target $INSTANCE_ID \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["7241"],"localPortNumber":["7241"]}'
+```
+
+Then open http://localhost:7241 in your browser.
+
+## Verify
+
+- The UI loads and shows a list of projects from your S3 bucket
+- Navigate into a project to see tracked application runs
+- If the bucket is empty, the UI shows an empty project list (no errors)
+
+## Teardown
+
+```bash
+terraform destroy -var-file=my.tfvars
+```
+
+## Security
+
+- **No public IP.** The instance is in a private subnet with no inbound security group rules.
+- **No SSH.** Access is exclusively via SSM Session Manager (port forwarding).
+- **No open ports.** The security group allows egress only (for pip install and S3 access).
+- **IMDSv2 enforced.** Instance metadata requires session tokens.
+- **Encrypted EBS.** Root volume uses gp3 with encryption enabled.
+- **Least-privilege IAM.** The instance role has read-only access to the single specified bucket.
+- **VPC endpoints for SSM.** SSM control plane traffic stays within the VPC.
+
+## Architecture Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Single EC2 instance | Issue #391 requests single-tenant. The UI is read-heavy and not write-bound. |
+| SSM over bastion/ALB | Simplest private access. No key management, no extra instances, no public endpoints. |
+| NAT Gateway | Required for pip install on boot. Could be replaced with VPC endpoint for S3 + pre-baked AMI. |
+| No bucket creation | Issue says "parameterizable on the S3 bucket" — assumes an existing one. |
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| SSM can't connect | Ensure the SSM plugin is installed and the instance has `AmazonSSMManagedInstanceCore` policy |
+| UI loads but no projects | Check that `s3_bucket_name` matches your tracking bucket and the region is correct |
+| Server not starting | SSM into the instance: `sudo journalctl -u burr-ui` |
+| Indexing errors | Check `/var/log/burr-ui-setup.log` on the instance |
+
+## Production Notes
+
+- For team access, place an internal ALB in front and connect via VPN
+- For HTTPS, add an ACM certificate and ALB listener
+- For persistent index across restarts, enable S3 snapshot (set `BURR_LOAD_SNAPSHOT_ON_START=true`)
+- See [S3 Tracking on AWS](https://burr.apache.org/concepts/aws-tracking/) for all configuration options

--- a/examples/deployment/aws/burr-ui/README.md
+++ b/examples/deployment/aws/burr-ui/README.md
@@ -32,28 +32,23 @@ This deploys a single-tenant Burr UI server that:
 - Is accessible only via SSM port forwarding (no public internet exposure)
 - Uses a single EC2 instance (not horizontally scaled — by design)
 
-```
-┌─────────────────────────────────────────────────────────┐
-│ VPC (10.0.0.0/16)                                       │
-│                                                         │
-│  ┌─────────────────────────────────────────────────┐    │
-│  │ Private Subnet                                  │    │
-│  │                                                 │    │
-│  │  ┌──────────────────────────┐                   │    │
-│  │  │ EC2 (t3.small)           │                   │    │
-│  │  │ - burr --no-open         │                   │    │
-│  │  │ - port 7241              │                   │    │
-│  │  │ - BURR_S3_BUCKET=...     │──── reads ──── S3 │    │
-│  │  └──────────────────────────┘                   │    │
-│  └─────────────────────────────────────────────────┘    │
-│                                                         │
-│  SSM VPC Endpoints (ssm, ssmmessages, ec2messages)      │
-│  NAT Gateway (outbound for pip install)                 │
-└─────────────────────────────────────────────────────────┘
-         │
-         │ SSM port-forward (your laptop)
-         ▼
-   http://localhost:7241
+```mermaid
+graph TB
+    subgraph VPC["VPC (10.0.0.0/16)"]
+        subgraph Private["Private Subnet"]
+            EC2["EC2 (t3.small)<br/>burr --no-open<br/>port 7241<br/>BURR_S3_BUCKET=..."]
+        end
+        NAT["NAT Gateway"]
+        SSM_EP["SSM VPC Endpoints"]
+    end
+
+    S3["S3 Bucket<br/>(existing tracking data)"]
+    User["Your Laptop<br/>http://localhost:7241"]
+
+    EC2 -->|"reads tracking logs"| S3
+    EC2 -->|"outbound via NAT"| NAT
+    EC2 --- SSM_EP
+    User -->|"SSM port-forward 7241"| SSM_EP
 ```
 
 ## Prerequisites

--- a/examples/deployment/aws/burr-ui/requirements.txt
+++ b/examples/deployment/aws/burr-ui/requirements.txt
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apache-burr[tracking-server-s3,cli]

--- a/examples/deployment/aws/burr-ui/terraform/.gitignore
+++ b/examples/deployment/aws/burr-ui/terraform/.gitignore
@@ -1,0 +1,11 @@
+*.tfstate
+*.tfstate.backup
+*.tfplan
+.terraform/
+.terraform.lock.hcl
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+*.auto.tfvars

--- a/examples/deployment/aws/burr-ui/terraform/environments/dev.tfvars
+++ b/examples/deployment/aws/burr-ui/terraform/environments/dev.tfvars
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+aws_region       = "us-east-1"
+environment      = "dev"
+instance_type    = "t3.small"
+root_volume_size = 20
+
+# REQUIRED — set to your existing Burr tracking bucket:
+# s3_bucket_name = "my-burr-tracking-logs"

--- a/examples/deployment/aws/burr-ui/terraform/environments/prod.tfvars
+++ b/examples/deployment/aws/burr-ui/terraform/environments/prod.tfvars
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+aws_region       = "us-east-1"
+environment      = "prod"
+instance_type    = "t3.small"
+root_volume_size = 30
+
+# REQUIRED — set to your existing Burr tracking bucket:
+# s3_bucket_name = "my-burr-tracking-logs"

--- a/examples/deployment/aws/burr-ui/terraform/main.tf
+++ b/examples/deployment/aws/burr-ui/terraform/main.tf
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+locals {
+  common_tags = {
+    Project     = "burr-ui-server"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+module "networking" {
+  source = "./modules/networking"
+
+  environment = var.environment
+  vpc_cidr    = var.vpc_cidr
+  aws_region  = var.aws_region
+}
+
+module "iam" {
+  source = "./modules/iam"
+
+  environment    = var.environment
+  s3_bucket_name = var.s3_bucket_name
+}
+
+module "compute" {
+  source = "./modules/compute"
+
+  environment          = var.environment
+  instance_type        = var.instance_type
+  root_volume_size     = var.root_volume_size
+  s3_bucket_name       = var.s3_bucket_name
+  subnet_id            = module.networking.private_subnet_id
+  security_group_id    = module.networking.security_group_id
+  instance_profile_arn = module.iam.instance_profile_arn
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/compute/main.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/compute/main.tf
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.security_group_id]
+  iam_instance_profile   = var.instance_profile_arn
+
+  user_data = templatefile("${path.module}/templates/user_data.sh.tpl", {
+    s3_bucket_name = var.s3_bucket_name
+  })
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = var.root_volume_size
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  tags = {
+    Name = "burr-ui-${var.environment}"
+  }
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/compute/outputs.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/compute/outputs.tf
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.this.id
+}
+
+output "private_ip" {
+  description = "Private IP address of the EC2 instance"
+  value       = aws_instance.this.private_ip
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/compute/templates/user_data.sh.tpl
+++ b/examples/deployment/aws/burr-ui/terraform/modules/compute/templates/user_data.sh.tpl
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+exec > >(tee /var/log/burr-ui-setup.log) 2>&1
+echo "=== Burr UI server setup started at $(date) ==="
+
+# Install Python and pip
+yum update -y
+yum install -y python3.11 python3.11-pip
+
+# Install the Burr tracking server with S3 backend
+python3.11 -m pip install "apache-burr[tracking-server-s3,cli]"
+
+# Create a systemd service for the Burr UI
+cat > /etc/systemd/system/burr-ui.service <<EOF
+[Unit]
+Description=Burr Tracking UI Server
+After=network.target
+
+[Service]
+Type=simple
+Environment=BURR_S3_BUCKET=${s3_bucket_name}
+ExecStart=/usr/local/bin/burr --no-open --host 0.0.0.0
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable burr-ui
+systemctl start burr-ui
+
+echo "=== Burr UI server setup completed at $(date) ==="
+echo "=== Server listening on port 7241, reading from s3://${s3_bucket_name} ==="

--- a/examples/deployment/aws/burr-ui/terraform/modules/compute/variables.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/compute/variables.tf
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "root_volume_size" {
+  description = "Root EBS volume size in GB"
+  type        = number
+}
+
+variable "s3_bucket_name" {
+  description = "S3 bucket name for BURR_S3_BUCKET env var"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to launch the instance in"
+  type        = string
+}
+
+variable "security_group_id" {
+  description = "Security group ID"
+  type        = string
+}
+
+variable "instance_profile_arn" {
+  description = "IAM instance profile ARN"
+  type        = string
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/iam/main.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/iam/main.tf
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = "burr-ui-${var.environment}-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+
+  tags = {
+    Name = "burr-ui-${var.environment}-role"
+  }
+}
+
+# Read-only access to the tracking S3 bucket (least privilege)
+data "aws_iam_policy_document" "s3_read" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:HeadObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}",
+      "arn:aws:s3:::${var.s3_bucket_name}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "s3_read" {
+  name   = "burr-ui-s3-read"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.s3_read.json
+}
+
+# SSM Session Manager access (allows port forwarding without open ports)
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "burr-ui-${var.environment}-profile"
+  role = aws_iam_role.this.name
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/iam/outputs.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/iam/outputs.tf
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+output "instance_profile_arn" {
+  description = "IAM instance profile ARN"
+  value       = aws_iam_instance_profile.this.arn
+}
+
+output "role_arn" {
+  description = "IAM role ARN"
+  value       = aws_iam_role.this.arn
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/iam/variables.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/iam/variables.tf
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "S3 bucket name to grant read access to"
+  type        = string
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/networking/main.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/networking/main.tf
@@ -1,0 +1,191 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# --- VPC ---
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "burr-ui-${var.environment}-vpc"
+  }
+}
+
+# --- Subnets ---
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, 1)
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "burr-ui-${var.environment}-private"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, 100)
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "burr-ui-${var.environment}-public"
+  }
+}
+
+# --- Internet Gateway (for NAT) ---
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "burr-ui-${var.environment}-igw"
+  }
+}
+
+# --- NAT Gateway (allows private subnet outbound for pip install + S3 access) ---
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "burr-ui-${var.environment}-nat-eip"
+  }
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public.id
+
+  tags = {
+    Name = "burr-ui-${var.environment}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# --- Route Tables ---
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "burr-ui-${var.environment}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = {
+    Name = "burr-ui-${var.environment}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
+}
+
+# --- Security Group (egress-only; SSM needs no inbound ports) ---
+
+resource "aws_security_group" "this" {
+  name        = "burr-ui-${var.environment}-sg"
+  description = "Burr UI server - egress only (access via SSM, no inbound ports)"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "burr-ui-${var.environment}-sg"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "egress_all" {
+  type              = "egress"
+  description       = "Allow all outbound (pip install, S3 access, SSM)"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.this.id
+}
+
+# --- VPC Endpoints for SSM (allows SSM without NAT for the SSM control plane) ---
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private.id]
+  security_group_ids  = [aws_security_group.this.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "burr-ui-${var.environment}-ssm-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private.id]
+  security_group_ids  = [aws_security_group.this.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "burr-ui-${var.environment}-ssmmessages-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.ec2messages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private.id]
+  security_group_ids  = [aws_security_group.this.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "burr-ui-${var.environment}-ec2messages-endpoint"
+  }
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/networking/outputs.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/networking/outputs.tf
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.this.id
+}
+
+output "private_subnet_id" {
+  description = "Private subnet ID"
+  value       = aws_subnet.private.id
+}
+
+output "security_group_id" {
+  description = "Security group ID (egress-only)"
+  value       = aws_security_group.this.id
+}

--- a/examples/deployment/aws/burr-ui/terraform/modules/networking/variables.tf
+++ b/examples/deployment/aws/burr-ui/terraform/modules/networking/variables.tf
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}

--- a/examples/deployment/aws/burr-ui/terraform/outputs.tf
+++ b/examples/deployment/aws/burr-ui/terraform/outputs.tf
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+output "instance_id" {
+  description = "EC2 instance ID (use with SSM port-forward)"
+  value       = module.compute.instance_id
+}
+
+output "private_ip" {
+  description = "Private IP of the Burr UI server"
+  value       = module.compute.private_ip
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.networking.vpc_id
+}
+
+output "ssm_port_forward_command" {
+  description = "Command to access the Burr UI via SSM port forwarding"
+  value       = "aws ssm start-session --target ${module.compute.instance_id} --document-name AWS-StartPortForwardingSession --parameters '{\"portNumber\":[\"7241\"],\"localPortNumber\":[\"7241\"]}'"
+}
+
+output "ui_url" {
+  description = "URL to access the Burr UI after port forwarding"
+  value       = "http://localhost:7241"
+}

--- a/examples/deployment/aws/burr-ui/terraform/variables.tf
+++ b/examples/deployment/aws/burr-ui/terraform/variables.tf
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# Required Variables
+# -----------------------------------------------------------------------------
+
+variable "s3_bucket_name" {
+  description = "Name of the existing S3 bucket containing Burr tracking logs"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# Optional Variables
+# -----------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "AWS region to deploy in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the Burr UI server"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "root_volume_size" {
+  description = "Size of the root EBS volume in GB"
+  type        = number
+  default     = 20
+
+  validation {
+    condition     = var.root_volume_size >= 8
+    error_message = "root_volume_size must be at least 8 GB."
+  }
+}

--- a/examples/deployment/aws/burr-ui/terraform/versions.tf
+++ b/examples/deployment/aws/burr-ui/terraform/versions.tf
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/tests/deployment/test_burr_ui_example.py
+++ b/tests/deployment/test_burr_ui_example.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the Burr UI on AWS deployment example.
+
+Validate structure and security without provisioning real infrastructure.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).parents[2] / "examples" / "deployment" / "aws" / "burr-ui"
+
+
+class TestExampleStructure:
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "README.md",
+            "Dockerfile",
+            "requirements.txt",
+            "terraform/main.tf",
+            "terraform/variables.tf",
+            "terraform/outputs.tf",
+            "terraform/versions.tf",
+            "terraform/modules/networking/main.tf",
+            "terraform/modules/networking/variables.tf",
+            "terraform/modules/networking/outputs.tf",
+            "terraform/modules/compute/main.tf",
+            "terraform/modules/compute/variables.tf",
+            "terraform/modules/compute/outputs.tf",
+            "terraform/modules/compute/templates/user_data.sh.tpl",
+            "terraform/modules/iam/main.tf",
+            "terraform/modules/iam/variables.tf",
+            "terraform/modules/iam/outputs.tf",
+        ],
+    )
+    def test_required_file_exists(self, rel):
+        assert (EXAMPLE_DIR / rel).is_file(), f"missing {rel}"
+
+
+class TestApacheLicenseHeaders:
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "README.md",
+            "Dockerfile",
+            "requirements.txt",
+            "terraform/main.tf",
+            "terraform/variables.tf",
+            "terraform/outputs.tf",
+            "terraform/versions.tf",
+            "terraform/environments/dev.tfvars",
+            "terraform/environments/prod.tfvars",
+            "terraform/modules/networking/main.tf",
+            "terraform/modules/networking/variables.tf",
+            "terraform/modules/networking/outputs.tf",
+            "terraform/modules/compute/main.tf",
+            "terraform/modules/compute/variables.tf",
+            "terraform/modules/compute/outputs.tf",
+            "terraform/modules/compute/templates/user_data.sh.tpl",
+            "terraform/modules/iam/main.tf",
+            "terraform/modules/iam/variables.tf",
+            "terraform/modules/iam/outputs.tf",
+        ],
+    )
+    def test_has_header(self, rel):
+        p = EXAMPLE_DIR / rel
+        if p.exists():
+            assert "Licensed to the Apache Software Foundation" in p.read_text(encoding="utf-8"), (
+                f"{rel} is missing the Apache license header"
+            )
+
+
+class TestBucketParameterization:
+    def test_s3_bucket_variable_declared(self):
+        v = (EXAMPLE_DIR / "terraform" / "variables.tf").read_text()
+        assert "s3_bucket_name" in v
+
+    def test_user_data_sets_bucket_env(self):
+        ud = (
+            EXAMPLE_DIR / "terraform" / "modules" / "compute" / "templates" / "user_data.sh.tpl"
+        ).read_text()
+        assert "BURR_S3_BUCKET" in ud
+        assert "burr" in ud
+
+
+class TestSecurity:
+    def test_imdsv2_enforced(self):
+        c = (EXAMPLE_DIR / "terraform" / "modules" / "compute" / "main.tf").read_text()
+        assert "http_tokens" in c and "required" in c
+
+    def test_ebs_encrypted(self):
+        c = (EXAMPLE_DIR / "terraform" / "modules" / "compute" / "main.tf").read_text()
+        assert "encrypted" in c and "true" in c
+
+    def test_no_ingress_rules(self):
+        """With SSM access, the security group should have NO ingress rules."""
+        net_main = (
+            EXAMPLE_DIR / "terraform" / "modules" / "networking" / "main.tf"
+        ).read_text()
+        # There should be no aws_security_group_rule with type = "ingress"
+        assert 'type              = "ingress"' not in net_main, (
+            "Security group should have no ingress rules (SSM access only)"
+        )
+
+    def test_iam_read_only(self):
+        """IAM policy should only have read actions, no write/delete."""
+        iam_main = (EXAMPLE_DIR / "terraform" / "modules" / "iam" / "main.tf").read_text()
+        assert "s3:GetObject" in iam_main
+        assert "s3:PutObject" not in iam_main
+        assert "s3:DeleteObject" not in iam_main
+
+    def test_ssm_core_policy_attached(self):
+        """Instance must have AmazonSSMManagedInstanceCore for SSM access."""
+        iam_main = (EXAMPLE_DIR / "terraform" / "modules" / "iam" / "main.tf").read_text()
+        assert "AmazonSSMManagedInstanceCore" in iam_main
+
+
+class TestTerraformValidate:
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_terraform(self):
+        if subprocess.run(["terraform", "version"], capture_output=True).returncode != 0:
+            pytest.skip("terraform not installed")
+
+    def test_fmt(self):
+        r = subprocess.run(
+            ["terraform", "fmt", "-check", "-recursive"],
+            cwd=EXAMPLE_DIR / "terraform",
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 0, f"terraform fmt failed:\n{r.stdout}"
+
+    def test_validate(self):
+        subprocess.run(
+            ["terraform", "init", "-backend=false"],
+            cwd=EXAMPLE_DIR / "terraform",
+            capture_output=True,
+        )
+        r = subprocess.run(
+            ["terraform", "validate"],
+            cwd=EXAMPLE_DIR / "terraform",
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 0, f"terraform validate failed:\n{r.stderr}"

--- a/tests/deployment/test_burr_ui_example.py
+++ b/tests/deployment/test_burr_ui_example.py
@@ -20,6 +20,7 @@
 Validate structure and security without provisioning real infrastructure.
 """
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -83,9 +84,9 @@ class TestApacheLicenseHeaders:
     def test_has_header(self, rel):
         p = EXAMPLE_DIR / rel
         if p.exists():
-            assert "Licensed to the Apache Software Foundation" in p.read_text(encoding="utf-8"), (
-                f"{rel} is missing the Apache license header"
-            )
+            assert "Licensed to the Apache Software Foundation" in p.read_text(
+                encoding="utf-8"
+            ), f"{rel} is missing the Apache license header"
 
 
 class TestBucketParameterization:
@@ -95,7 +96,12 @@ class TestBucketParameterization:
 
     def test_user_data_sets_bucket_env(self):
         ud = (
-            EXAMPLE_DIR / "terraform" / "modules" / "compute" / "templates" / "user_data.sh.tpl"
+            EXAMPLE_DIR
+            / "terraform"
+            / "modules"
+            / "compute"
+            / "templates"
+            / "user_data.sh.tpl"
         ).read_text()
         assert "BURR_S3_BUCKET" in ud
         assert "burr" in ud
@@ -116,27 +122,37 @@ class TestSecurity:
             EXAMPLE_DIR / "terraform" / "modules" / "networking" / "main.tf"
         ).read_text()
         # There should be no aws_security_group_rule with type = "ingress"
-        assert 'type              = "ingress"' not in net_main, (
-            "Security group should have no ingress rules (SSM access only)"
-        )
+        assert (
+            'type              = "ingress"' not in net_main
+        ), "Security group should have no ingress rules (SSM access only)"
 
     def test_iam_read_only(self):
         """IAM policy should only have read actions, no write/delete."""
-        iam_main = (EXAMPLE_DIR / "terraform" / "modules" / "iam" / "main.tf").read_text()
+        iam_main = (
+            EXAMPLE_DIR / "terraform" / "modules" / "iam" / "main.tf"
+        ).read_text()
         assert "s3:GetObject" in iam_main
         assert "s3:PutObject" not in iam_main
         assert "s3:DeleteObject" not in iam_main
 
     def test_ssm_core_policy_attached(self):
         """Instance must have AmazonSSMManagedInstanceCore for SSM access."""
-        iam_main = (EXAMPLE_DIR / "terraform" / "modules" / "iam" / "main.tf").read_text()
+        iam_main = (
+            EXAMPLE_DIR / "terraform" / "modules" / "iam" / "main.tf"
+        ).read_text()
         assert "AmazonSSMManagedInstanceCore" in iam_main
 
 
 class TestTerraformValidate:
     @pytest.fixture(autouse=True)
     def _skip_if_no_terraform(self):
-        if subprocess.run(["terraform", "version"], capture_output=True).returncode != 0:
+        if shutil.which("terraform") is None:
+            pytest.skip("terraform not installed")
+        try:
+            result = subprocess.run(["terraform", "version"], capture_output=True)
+        except FileNotFoundError:
+            pytest.skip("terraform not installed")
+        if result.returncode != 0:
             pytest.skip("terraform not installed")
 
     def test_fmt(self):


### PR DESCRIPTION
Adds a deployment example for running the Burr tracking UI server on AWS in a private VPC, reading from an existing S3 tracking bucket. Directly addresses Issue #391 requirements: inside a VPC, parameterizable on S3 bucket, single-tenant server, Terraform.

Architecture: Private VPC with NAT Gateway, SSM VPC Endpoints, EC2 running burr as systemd service, read-only IAM to single bucket, access via SSM port forwarding.

Security: No public IP, no inbound ports, IMDSv2, encrypted EBS, least-privilege IAM, no SSH keys.

Testing: terraform fmt/validate pass, 45 pytest tests pass (structure, license, security, bucket parameterization).

Files: 21 created in examples/deployment/aws/burr-ui/, 1 test, 1 RST doc, 1 toctree update.

Addresses #391
