### PR TITLE
feat: add lower-level parallel streaming support

### DIFF
--- a/burr/core/parallelism.py
+++ b/burr/core/parallelism.py
@@ -21,6 +21,7 @@ import dataclasses
 import hashlib
 import inspect
 import logging
+import queue
 from typing import (
     Any,
     AsyncGenerator,
@@ -38,7 +39,7 @@ from typing import (
 from burr.common import async_utils
 from burr.common.async_utils import SyncOrAsyncGenerator, SyncOrAsyncGeneratorOrItemOrList
 from burr.core import Action, ApplicationBuilder, ApplicationContext, Graph, State
-from burr.core.action import SingleStepAction
+from burr.core.action import SingleStepStreamingAction
 from burr.core.application import ApplicationIdentifiers
 from burr.core.graph import GraphBuilder
 from burr.core.persistence import BaseStateLoader, BaseStateSaver
@@ -171,6 +172,89 @@ class SubGraphTask:
         )
         return state
 
+    def stream(
+        self,
+        parent_context: ApplicationContext,
+        *,
+        task_key: str,
+        intermediate_stream_outputs: bool,
+        intermediate_nodes: bool,
+    ) -> Generator["StreamItem", None, None]:
+        """Streams results from the sub-application using Application.stream_iterate."""
+        app = self._create_app_builder(parent_context).build()
+        filtered_inputs = {
+            key: value for key, value in self.inputs.items() if not key.startswith("__")
+        }
+        for action, streaming_result in app.stream_iterate(
+            halt_after=self.graph.halt_after, inputs=filtered_inputs
+        ):
+            should_emit_node = intermediate_nodes or action.name in self.graph.halt_after
+            if intermediate_stream_outputs and should_emit_node:
+                for item in streaming_result:
+                    yield StreamItem(
+                        result=item,
+                        state_update=None,
+                        action=action,
+                        task_key=task_key,
+                        application_id=self.application_id,
+                    )
+            result, state = streaming_result.get()
+            if should_emit_node:
+                yield StreamItem(
+                    result=result,
+                    state_update=state,
+                    action=action,
+                    task_key=task_key,
+                    application_id=self.application_id,
+                )
+
+    async def astream(
+        self,
+        parent_context: ApplicationContext,
+        *,
+        task_key: str,
+        intermediate_stream_outputs: bool,
+        intermediate_nodes: bool,
+    ) -> AsyncGenerator["StreamItem", None]:
+        """Streams results from the sub-application using Application.astream_iterate."""
+        app = await self._create_app_builder(parent_context).abuild()
+        filtered_inputs = {
+            key: value for key, value in self.inputs.items() if not key.startswith("__")
+        }
+        async for action, streaming_result in app.astream_iterate(
+            halt_after=self.graph.halt_after, inputs=filtered_inputs
+        ):
+            should_emit_node = intermediate_nodes or action.name in self.graph.halt_after
+            if intermediate_stream_outputs and should_emit_node:
+                async for item in streaming_result:
+                    yield StreamItem(
+                        result=item,
+                        state_update=None,
+                        action=action,
+                        task_key=task_key,
+                        application_id=self.application_id,
+                    )
+            result, state = await streaming_result.get()
+            if should_emit_node:
+                yield StreamItem(
+                    result=result,
+                    state_update=state,
+                    action=action,
+                    task_key=task_key,
+                    application_id=self.application_id,
+                )
+
+
+@dataclasses.dataclass
+class StreamItem:
+    """Event emitted from a parallel streaming sub-application."""
+
+    result: Any
+    state_update: Optional[State]
+    action: Action
+    task_key: str
+    application_id: str
+
 
 def _stable_app_id_hash(app_id: str, child_key: str) -> str:
     """Gives a stable hash for an application. Given the parent app_id and a child key,
@@ -183,7 +267,7 @@ def _stable_app_id_hash(app_id: str, child_key: str) -> str:
     return hashlib.sha256(f"{app_id}:{child_key}".encode()).hexdigest()
 
 
-class TaskBasedParallelAction(SingleStepAction):
+class TaskBasedParallelAction(SingleStepStreamingAction):
     """The base class for actions that run a set of tasks in parallel and reduce the results.
     This is more power-user mode -- if you need fine-grained control over the set of tasks
     your parallel action utilizes, then this is for you. If not, you'll want to see:
@@ -248,8 +332,10 @@ class TaskBasedParallelAction(SingleStepAction):
     will be asynchronous as well (regardless of whether your task functions are asynchronous).
     """
 
-    def __init__(self):
+    def __init__(self, intermediate_stream_outputs: bool = True, intermediate_nodes: bool = True):
         super().__init__()
+        self._intermediate_stream_outputs = intermediate_stream_outputs
+        self._intermediate_nodes = intermediate_nodes
 
     def run_and_update(self, state: State, **run_kwargs) -> Tuple[dict, State]:
         """Runs and updates. This is not user-facing, so do not override it.
@@ -307,6 +393,142 @@ class TaskBasedParallelAction(SingleStepAction):
         if self.is_async():
             return _arun_and_update()  # type: ignore
         return _run_and_update()
+
+    def stream_run_and_update(
+        self, state: State, **run_kwargs
+    ) -> Union[Generator[Tuple[StreamItem, Optional[State]], None, None], AsyncGenerator]:
+        """Streaming counterpart to run_and_update for parallel actions."""
+        if self.is_async():
+            return self._astream_run_and_update(state, **run_kwargs)
+        return self._stream_run_and_update(state, **run_kwargs)
+
+    def _stream_run_and_update(
+        self, state: State, **run_kwargs
+    ) -> Generator[Tuple[StreamItem, Optional[State]], None, None]:
+        context: ApplicationContext = run_kwargs.get("__context")
+        if context is None:
+            raise ValueError("This action requires a context to run")
+        state_without_internals = state.wipe(
+            delete=[item for item in state.keys() if item.startswith("__")]
+        )
+        tasks = list(self.tasks(state_without_internals, context, run_kwargs))
+        emitted_results: "queue.Queue[StreamItem]" = queue.Queue()
+
+        def execute_task(task_index: int, task: SubGraphTask) -> Tuple[int, State]:
+            task_key = str(task_index)
+            final_state = None
+            for item in task.stream(
+                context,
+                task_key=task_key,
+                intermediate_stream_outputs=self._intermediate_stream_outputs,
+                intermediate_nodes=self._intermediate_nodes,
+            ):
+                if item.state_update is not None:
+                    final_state = item.state_update
+                emitted_results.put(item)
+            if final_state is None:
+                raise ValueError(
+                    "Parallel streaming task did not emit a final state update. "
+                    "Ensure the subgraph halts on a concrete node."
+                )
+            return task_index, final_state
+
+        final_states: Dict[int, State] = {}
+        with context.parallel_executor_factory() as executor:
+            if not hasattr(executor, "submit"):
+                raise TypeError("Parallel streaming requires an executor that supports submit().")
+            futures = [
+                executor.submit(execute_task, task_index, task)
+                for task_index, task in enumerate(tasks)
+            ]
+            while futures:
+                try:
+                    item = emitted_results.get(timeout=0.01)
+                    yield item, None
+                    continue
+                except queue.Empty:
+                    pass
+                still_running = []
+                for future in futures:
+                    if future.done():
+                        task_index, final_state = future.result()
+                        final_states[task_index] = final_state
+                    else:
+                        still_running.append(future)
+                futures = still_running
+            while not emitted_results.empty():
+                yield emitted_results.get(), None
+
+        def state_generator() -> Generator[State, None, None]:
+            for task_index in range(len(tasks)):
+                yield final_states[task_index]
+
+        final_state = self.reduce(state_without_internals, state_generator())
+        final_state = final_state.update(
+            **{key: value for key, value in state.get_all().items() if key.startswith("__")}
+        )
+        yield {}, final_state
+
+    async def _astream_run_and_update(
+        self, state: State, **run_kwargs
+    ) -> AsyncGenerator[Tuple[StreamItem, Optional[State]], None]:
+        context: ApplicationContext = run_kwargs.get("__context")
+        if context is None:
+            raise ValueError("This action requires a context to run")
+        state_without_internals = state.wipe(
+            delete=[item for item in state.keys() if item.startswith("__")]
+        )
+        all_tasks = await async_utils.arealize(self.tasks(state_without_internals, context, run_kwargs))
+        emitted_results: asyncio.Queue[StreamItem] = asyncio.Queue()
+
+        async def execute_task(task_index: int, task: SubGraphTask) -> Tuple[int, State]:
+            task_key = str(task_index)
+            final_state = None
+            async for item in task.astream(
+                context,
+                task_key=task_key,
+                intermediate_stream_outputs=self._intermediate_stream_outputs,
+                intermediate_nodes=self._intermediate_nodes,
+            ):
+                if item.state_update is not None:
+                    final_state = item.state_update
+                await emitted_results.put(item)
+            if final_state is None:
+                raise ValueError(
+                    "Parallel streaming task did not emit a final state update. "
+                    "Ensure the subgraph halts on a concrete node."
+                )
+            return task_index, final_state
+
+        workers = [asyncio.create_task(execute_task(i, task)) for i, task in enumerate(all_tasks)]
+        final_states: Dict[int, State] = {}
+        while workers:
+            try:
+                item = await asyncio.wait_for(emitted_results.get(), timeout=0.01)
+                yield item, None
+                continue
+            except asyncio.TimeoutError:
+                pass
+            pending_workers = []
+            for worker in workers:
+                if worker.done():
+                    task_index, final_state = await worker
+                    final_states[task_index] = final_state
+                else:
+                    pending_workers.append(worker)
+            workers = pending_workers
+        while not emitted_results.empty():
+            yield await emitted_results.get(), None
+
+        async def state_generator() -> AsyncGenerator[State, None]:
+            for task_index in range(len(all_tasks)):
+                yield final_states[task_index]
+
+        final_state = await self.reduce(state_without_internals, state_generator())
+        final_state = final_state.update(
+            **{key: value for key, value in state.get_all().items() if key.startswith("__")}
+        )
+        yield {}, final_state
 
     def is_async(self) -> bool:
         """This says whether or not the action is async. Note you have to override this if you have async tasks

--- a/docs/concepts/parallelism.rst
+++ b/docs/concepts/parallelism.rst
@@ -576,9 +576,28 @@ Things we will consider after the initial release:
 
 - Customizing execution on a per-action basis -- likely a parameter to ``RunnableGraph``
 - Customizing tracking keys for parallelism
-- Streaming -- interleaving parallel streaming actions and giving results as they come
 - More examples for inter-graph communication/cancellation of one action based on the result of another
 - Graceful failure of sub-actions
+
+
+Parallel Streaming
+------------------
+
+``TaskBasedParallelAction`` can now act as a lower-level streaming primitive for subgraphs that
+contain streaming nodes. When you call :py:meth:`burr.core.application.Application.stream_result`
+or :py:meth:`burr.core.application.Application.astream_result` on a parallel action, Burr will:
+
+1. Execute subgraphs in parallel
+2. Emit :py:class:`burr.core.parallelism.StreamItem` events as results arrive
+3. Preserve the original task ordering when calling ``reduce(...)`` to build the final state
+
+Each ``StreamItem`` includes the emitted result, any completed state update for the node,
+the action that produced it, a task key, and the sub-application ID.
+
+You can control how much intermediate output is surfaced by constructing the action with:
+
+- ``intermediate_stream_outputs=False`` to suppress token-by-token events from streaming nodes
+- ``intermediate_nodes=False`` to suppress non-terminal node completion events and only emit the terminal node per task
 
 Under the hood
 ==============

--- a/tests/core/test_parallelism.py
+++ b/tests/core/test_parallelism.py
@@ -19,6 +19,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import datetime
+import time
 from random import random
 from typing import Any, AsyncGenerator, Callable, Dict, Generator, List, Literal, Optional, Union
 
@@ -33,13 +34,14 @@ from burr.core import (
     State,
     action,
 )
-from burr.core.action import Input, Result
+from burr.core.action import Input, Result, streaming_action
 from burr.core.graph import GraphBuilder
 from burr.core.parallelism import (
     MapActions,
     MapActionsAndStates,
     MapStates,
     RunnableGraph,
+    StreamItem,
     SubGraphTask,
     TaskBasedParallelAction,
     _cascade_adapter,
@@ -167,6 +169,30 @@ async def final_result_async(state: State) -> State:
     return final_result(state)
 
 
+@streaming_action(reads=["current_number"], writes=["output_number"])
+def streaming_final_result(
+    state: State, additional_number: int = 1, identifying_number: int = 3000
+) -> Generator[tuple[dict, Optional[State]], None, None]:
+    current_number = state["current_number"]
+    yield {"token": current_number}, None
+    time.sleep(0.001)
+    yield {"token": current_number + additional_number}, None
+    final_value = current_number + additional_number + identifying_number
+    yield {"output_number": final_value}, state.update(output_number=final_value)
+
+
+@streaming_action(reads=["current_number"], writes=["output_number"])
+async def streaming_final_result_async(
+    state: State, additional_number: int = 1, identifying_number: int = 3000
+) -> AsyncGenerator[tuple[dict, Optional[State]], None]:
+    current_number = state["current_number"]
+    yield {"token": current_number}, None
+    await asyncio.sleep(0)
+    yield {"token": current_number + additional_number}, None
+    final_value = current_number + additional_number + identifying_number
+    yield {"output_number": final_value}, state.update(output_number=final_value)
+
+
 SubGraphType = Union[Action, Callable, RunnableGraph]
 
 
@@ -211,6 +237,46 @@ def create_full_subgraph_async(identifying_number: int = 0) -> SubGraphType:
         .build(),
         entrypoint="entry_action_for_subgraph",
         halt_after=["final_result"],
+    )
+
+
+def create_streaming_subgraph(identifying_number: int = 0) -> SubGraphType:
+    return RunnableGraph(
+        graph=(
+            GraphBuilder()
+            .with_actions(
+                entry_action_for_subgraph,
+                add_number_to_add,
+                streaming_final_result.bind(identifying_number=identifying_number),
+            )
+            .with_transitions(
+                ("entry_action_for_subgraph", "add_number_to_add"),
+                ("add_number_to_add", "streaming_final_result"),
+            )
+            .build()
+        ),
+        entrypoint="entry_action_for_subgraph",
+        halt_after=["streaming_final_result"],
+    )
+
+
+def create_streaming_subgraph_async(identifying_number: int = 0) -> SubGraphType:
+    return RunnableGraph(
+        graph=GraphBuilder()
+        .with_actions(
+            entry_action_for_subgraph=entry_action_for_subgraph_async,
+            add_number_to_add=add_number_to_add_async,
+            streaming_final_result=streaming_final_result_async.bind(
+                identifying_number=identifying_number
+            ),
+        )
+        .with_transitions(
+            ("entry_action_for_subgraph", "add_number_to_add"),
+            ("add_number_to_add", "streaming_final_result"),
+        )
+        .build(),
+        entrypoint="entry_action_for_subgraph",
+        halt_after=["streaming_final_result"],
     )
 
 
@@ -941,6 +1007,166 @@ async def test_task_level_API_e2e_async():
     _, map_event, __ = events
     grouped_events = _group_events_by_app_id(map_event.children)
     assert len(grouped_events) == 9  # cartesian product of 3 actions and 3 states
+
+
+def test_task_level_API_streaming_sync():
+    class StreamingTaskBasedAction(TaskBasedParallelAction):
+        def tasks(
+            self, state: State, context: ApplicationContext, inputs: Dict[str, Any]
+        ) -> Generator[SubGraphTask, None, None]:
+            for i, input_number in enumerate(state["input_numbers_in_state"]):
+                yield SubGraphTask(
+                    graph=create_streaming_subgraph(identifying_number=1000 + i),
+                    inputs={},
+                    state=state.update(input_number=input_number, number_to_add=10),
+                    application_id=f"streaming_sync_{i}",
+                )
+
+        def reduce(self, state: State, states: Generator[State, None, None]) -> State:
+            new_state = state
+            for output_state in states:
+                new_state = new_state.append(output_numbers_in_state=output_state["output_number"])
+            return new_state
+
+        @property
+        def writes(self) -> list[str]:
+            return ["output_numbers_in_state"]
+
+        @property
+        def reads(self) -> list[str]:
+            return ["input_numbers_in_state"]
+
+    app = (
+        ApplicationBuilder()
+        .with_actions(
+            initial_action=Input("input_numbers_in_state"),
+            map_action=StreamingTaskBasedAction(),
+            final_action=Result("output_numbers_in_state"),
+        )
+        .with_transitions(("initial_action", "map_action"), ("map_action", "final_action"))
+        .with_entrypoint("initial_action")
+        .build()
+    )
+    action, streaming_result = app.stream_result(
+        halt_after=["map_action"], inputs={"input_numbers_in_state": [100, 200]}
+    )
+    assert action.name == "map_action"
+    items = list(streaming_result)
+    assert len(items) == 10
+    assert all(isinstance(item, StreamItem) for item in items)
+    assert {item.task_key for item in items} == {"0", "1"}
+    assert {item.application_id for item in items} == {"streaming_sync_0", "streaming_sync_1"}
+    assert sum(item.state_update is not None for item in items) == 6
+    result, state = streaming_result.get()
+    assert result == {}
+    assert state["output_numbers_in_state"] == [1111, 1212]
+
+
+async def test_task_level_API_streaming_async():
+    class StreamingTaskBasedActionAsync(TaskBasedParallelAction):
+        async def tasks(
+            self, state: State, context: ApplicationContext, inputs: Dict[str, Any]
+        ) -> AsyncGenerator[SubGraphTask, None]:
+            for i, input_number in enumerate(state["input_numbers_in_state"]):
+                yield SubGraphTask(
+                    graph=create_streaming_subgraph_async(identifying_number=1000 + i),
+                    inputs={},
+                    state=state.update(input_number=input_number, number_to_add=10),
+                    application_id=f"streaming_async_{i}",
+                )
+
+        async def reduce(self, state: State, states: AsyncGenerator[State, None]) -> State:
+            new_state = state
+            async for output_state in states:
+                new_state = new_state.append(output_numbers_in_state=output_state["output_number"])
+            return new_state
+
+        @property
+        def writes(self) -> list[str]:
+            return ["output_numbers_in_state"]
+
+        @property
+        def reads(self) -> list[str]:
+            return ["input_numbers_in_state"]
+
+        def is_async(self) -> bool:
+            return True
+
+    app = (
+        ApplicationBuilder()
+        .with_actions(
+            initial_action=Input("input_numbers_in_state"),
+            map_action=StreamingTaskBasedActionAsync(),
+            final_action=Result("output_numbers_in_state"),
+        )
+        .with_transitions(("initial_action", "map_action"), ("map_action", "final_action"))
+        .with_entrypoint("initial_action")
+        .build()
+    )
+    action, streaming_result = await app.astream_result(
+        halt_after=["map_action"], inputs={"input_numbers_in_state": [100, 200]}
+    )
+    assert action.name == "map_action"
+    items = [item async for item in streaming_result]
+    assert len(items) == 10
+    assert all(isinstance(item, StreamItem) for item in items)
+    assert {item.task_key for item in items} == {"0", "1"}
+    assert {item.application_id for item in items} == {"streaming_async_0", "streaming_async_1"}
+    assert sum(item.state_update is not None for item in items) == 6
+    result, state = await streaming_result.get()
+    assert result == {}
+    assert state["output_numbers_in_state"] == [1111, 1212]
+
+
+def test_task_level_API_streaming_can_disable_token_events():
+    class StreamingTaskBasedAction(TaskBasedParallelAction):
+        def __init__(self):
+            super().__init__(intermediate_stream_outputs=False, intermediate_nodes=False)
+
+        def tasks(
+            self, state: State, context: ApplicationContext, inputs: Dict[str, Any]
+        ) -> Generator[SubGraphTask, None, None]:
+            for i, input_number in enumerate(state["input_numbers_in_state"]):
+                yield SubGraphTask(
+                    graph=create_streaming_subgraph(identifying_number=1000 + i),
+                    inputs={},
+                    state=state.update(input_number=input_number, number_to_add=10),
+                    application_id=f"streaming_disabled_{i}",
+                )
+
+        def reduce(self, state: State, states: Generator[State, None, None]) -> State:
+            new_state = state
+            for output_state in states:
+                new_state = new_state.append(output_numbers_in_state=output_state["output_number"])
+            return new_state
+
+        @property
+        def writes(self) -> list[str]:
+            return ["output_numbers_in_state"]
+
+        @property
+        def reads(self) -> list[str]:
+            return ["input_numbers_in_state"]
+
+    app = (
+        ApplicationBuilder()
+        .with_actions(
+            initial_action=Input("input_numbers_in_state"),
+            map_action=StreamingTaskBasedAction(),
+            final_action=Result("output_numbers_in_state"),
+        )
+        .with_transitions(("initial_action", "map_action"), ("map_action", "final_action"))
+        .with_entrypoint("initial_action")
+        .build()
+    )
+    _, streaming_result = app.stream_result(
+        halt_after=["map_action"], inputs={"input_numbers_in_state": [100, 200]}
+    )
+    items = list(streaming_result)
+    assert len(items) == 2
+    assert all(isinstance(item, StreamItem) for item in items)
+    assert all(item.state_update is not None for item in items)
+    assert {item.action.name for item in items} == {"streaming_final_result"}
 
 
 def test_map_reduce_function_e2e():


### PR DESCRIPTION
Closes #534.

## Summary
- make `TaskBasedParallelAction` stream-capable by extending it through Burr's existing streaming container flow
- add a `StreamItem` event type plus sync/async subgraph streaming helpers on `SubGraphTask`
- preserve stable task ordering for `reduce(...)` while allowing intermediate stream events to arrive as tasks complete
- add toggles for `intermediate_stream_outputs` and `intermediate_nodes` to control how much subgraph output is surfaced
- document the new lower-level parallel streaming capability in the parallelism guide

## Testing
- `python3 -m py_compile burr/core/parallelism.py tests/core/test_parallelism.py`
- `XDG_CACHE_HOME=/tmp/xdg-cache UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with pytest-asyncio --with pydantic pytest tests/core/test_parallelism.py -q -k "streaming"`
- `XDG_CACHE_HOME=/tmp/xdg-cache UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with pytest-asyncio --with pydantic pytest tests/core/test_parallelism.py -q`

## Notes
- This scopes the fix to the lower-level `TaskBasedParallelAction` capability described in the issue so the existing `Application.stream_result(...)` and `Application.astream_result(...)` APIs can surface parallel subgraph events without introducing a separate public streaming entrypoint.
- The broader queue/executor abstraction ideas from the issue body can still build on top of this in follow-up work if we want specialized multiprocessing or distributed backends later.