### PR TITLE
docs: fix broken CODE_OF_CONDUCT and developer setup links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,4 +257,4 @@ Apache Burr is released under the Apache 2.0 License. See [LICENSE](https://gith
 ## Contributing
 We're very supportive of changes by new contributors, big or small! Make sure to discuss potential changes by creating an issue or commenting on an existing one before opening a pull request. Good first contributions include creating an example or an integration with your favorite Python library!
 
- To contribute, checkout our [contributing guidelines](https://github.com/apache/burr/blob/main/CONTRIBUTING.rst), our [developer setup guide](https://github.com/apache/burr/blob/main/developer_setup.md), and our [Code of Conduct](https://github.com/apache/burr/blob/main/CODE_OF_CONDUCT.md).
+ To contribute, checkout our [contributing guidelines](https://github.com/apache/burr/blob/main/CONTRIBUTING.rst), our [developer setup guide](https://github.com/apache/burr/blob/main/docs/contributing/setup.rst), and the [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).


### PR DESCRIPTION
Closes #837
Fix two 404 links (Code of Conduct, developer setup guide) in the README "Contributing" section.

## Changes

- Point the developer setup guide link to `docs/contributing/setup.rst`.
- Point the Code of Conduct link to the ASF Code of Conduct policy page (`https://www.apache.org/foundation/policies/conduct.html`), consistent with `docs/asf/index.rst`.

## How I tested this

- Verified both old links return HTTP 404 on current `main`.
- Verified both new links return HTTP 200.
- Docs-only change — no code or functionality affected.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
