### PR TITLE
fix: use utf-8 in CI smoke server script

### DIFF
--- a/scripts/ci_smoke_server.py
+++ b/scripts/ci_smoke_server.py
@@ -153,7 +153,7 @@ def main() -> None:
         env = os.environ.copy()
         env["burr_path"] = str(burr_data_dir)
         env["PYTHONUNBUFFERED"] = "1"
-        with open(server_log, "w") as log_fh:
+        with open(server_log, "w", encoding="utf-8") as log_fh:
             server_proc = subprocess.Popen(
                 [str(venv_burr), "--port", str(port), "--no-open"],
                 cwd=str(work_dir),
@@ -168,7 +168,7 @@ def main() -> None:
             if server_proc.poll() is not None:
                 _log(f"Server process exited with code {server_proc.returncode}")
             _log("--- server log ---")
-            print(server_log.read_text(), flush=True)
+            print(server_log.read_text(encoding="utf-8"), flush=True)
             _log("--- end server log ---")
             _fail("Server did not become ready")
         _log("Server is up")
@@ -203,7 +203,8 @@ for _ in range(3):
     app.step()
 
 print(f"count={{app.state['count']}} app_id={{app.uid}}")
-"""
+""",
+            encoding="utf-8",
         )
         subprocess.run([str(venv_py), str(app_script)], check=True, cwd=str(work_dir), env=env)
 


### PR DESCRIPTION
## Problem
`scripts/ci_smoke_server.py` writes and reads text artifacts without specifying an encoding. On Windows or other non-UTF-8 default locales, the generated app script or captured server log can become locale-dependent even though the script content is text.

## Before / after
Before:
- The smoke server log was opened with the platform default text encoding.
- The failure log dump used `Path.read_text()` without an explicit encoding.
- The generated Burr app script used `Path.write_text()` without an explicit encoding.

After:
- All three text boundaries use `encoding="utf-8"`.
- Binary/network handling is unchanged.

## Verification
- `python -m py_compile scripts/ci_smoke_server.py`