### PR TITLE
Use UTF-8 for adaptive CRAG docs

### DIFF
--- a/examples/adaptive-crag/application.py
+++ b/examples/adaptive-crag/application.py
@@ -101,8 +101,9 @@ def load_burr_docs(
         files_iter = file_names
     docs = []
     for file in files_iter:
+        doc_path = (burr_docs_dir / Path(file).name).with_suffix(".txt")
         docs += merge_short_docs(
-            docs=(burr_docs_dir / Path(file).name).with_suffix(".txt").read_text().split("\n\n"),
+            docs=doc_path.read_text(encoding="utf-8").split("\n\n"),
             file_name=Path(file).stem,
             doc_thresh=doc_thresh,
         )


### PR DESCRIPTION
## Summary
- read adaptive CRAG example text documents with explicit UTF-8 encoding
- keep the existing short-document merge behavior unchanged

## Problem
`Path.read_text()` uses the platform default encoding when no encoding is provided. On Windows or other non-UTF-8 locales, the adaptive CRAG example can fail when docs contain non-ASCII content.

## Before / After
Before: docs were decoded with the local default encoding.

After: docs are decoded as UTF-8 consistently.

## Verification
- `python -m py_compile examples/adaptive-crag/application.py`