### PR TITLE
fix(release): surface bundled JavaScript licenses

### DIFF
--- a/LICENSE-bundled-js
+++ b/LICENSE-bundled-js
@@ -1,0 +1,110 @@
+/**
+ * @license React
+ * react-dom.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @license React
+ * react-jsx-runtime.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @license React
+ * react.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @license React
+ * scheduler.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @license React
+ * use-sync-external-store-shim.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @license React
+ * use-sync-external-store-shim/with-selector.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @remix-run/router v1.15.1
+ *
+ * Copyright (c) Remix Software Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.md file in the root directory of this source tree.
+ *
+ * @license MIT
+ */
+
+/**
+ * Prism: Lightweight, robust, elegant syntax highlighting
+ *
+ * @license MIT <https://opensource.org/licenses/MIT>
+ * @author Lea Verou <https://lea.verou.me>
+ * @namespace
+ * @public
+ */
+
+/**
+ * React Router DOM v6.22.1
+ *
+ * Copyright (c) Remix Software Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.md file in the root directory of this source tree.
+ *
+ * @license MIT
+ */
+
+/**
+ * React Router v6.22.1
+ *
+ * Copyright (c) Remix Software Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.md file in the root directory of this source tree.
+ *
+ * @license MIT
+ */
+
+/** @license React v16.13.1
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */

--- a/LICENSE-wheel
+++ b/LICENSE-wheel
@@ -230,5 +230,4 @@ SOFTWARE.
 -------------------------------
 
 Third-party JavaScript license notices for the bundled Burr UI are included
-under the wheel's .dist-info/licenses/burr/tracking/server/build/static/js/
-directory.
+in ``LICENSE-bundled-js``.

--- a/LICENSE-wheel
+++ b/LICENSE-wheel
@@ -226,3 +226,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------
+
+Third-party JavaScript license notices for the bundled Burr UI are included
+under the wheel's .dist-info/licenses/burr/tracking/server/build/static/js/
+directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,12 @@ maintainers = [
 ]
 description = "Apache Burr (incubating) makes it easy to develop applications that make decisions (chatbots, agents, simulations, etc...) from simple python building blocks."
 readme = "README.md"
-license-files = ["LICENSE-wheel", "NOTICE", "DISCLAIMER"]
+license-files = [
+  "LICENSE-wheel",
+  "NOTICE",
+  "DISCLAIMER",
+  "burr/tracking/server/build/static/js/main.*.js.LICENSE.txt",
+]
 keywords = ["mlops", "data", "state-machine", "llmops"]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ description = "Apache Burr (incubating) makes it easy to develop applications th
 readme = "README.md"
 license-files = [
   "LICENSE-wheel",
+  "LICENSE-bundled-js",
   "NOTICE",
   "DISCLAIMER",
-  "burr/tracking/server/build/static/js/main.*.js.LICENSE.txt",
 ]
 keywords = ["mlops", "data", "state-machine", "llmops"]
 classifiers = [
@@ -272,6 +272,7 @@ include = [
   "NOTICE",
   "DISCLAIMER",
   "LICENSE-wheel",
+  "LICENSE-bundled-js",
   "scripts/**",
   "telemetry/ui/**",
   "examples/__init__.py",

--- a/scripts/verify_apache_artifacts.py
+++ b/scripts/verify_apache_artifacts.py
@@ -62,6 +62,7 @@ PROJECT_SHORT_NAME = "burr"
 REQUIRED_TEXT_FILES = ("LICENSE", "NOTICE", "DISCLAIMER")
 WHEEL_LICENSE_FILES = ("LICENSE-wheel",)
 WHEEL_REQUIRED_TEXT_FILES = ("NOTICE", "DISCLAIMER") + WHEEL_LICENSE_FILES
+WHEEL_JS_LICENSE_SUFFIX = ".js.LICENSE.txt"
 PASS = "PASS"
 FAIL = "FAIL"
 SKIP = "SKIP"
@@ -411,6 +412,29 @@ def _verify_required_text_files(
     return all_valid
 
 
+def _verify_bundled_js_license(
+    artifact_name: str,
+    file_bytes: dict[str, bytes],
+    summary: VerificationSummary,
+) -> bool:
+    check_name = f"{artifact_name} contains bundled JavaScript licenses"
+    matches = [
+        path
+        for path in file_bytes
+        if any(part.endswith(".dist-info") for part in PurePosixPath(path).parts)
+        and "/licenses/burr/tracking/server/build/static/js/" in f"/{path}"
+        and path.endswith(WHEEL_JS_LICENSE_SUFFIX)
+    ]
+    if not matches:
+        print("    Missing bundled JavaScript license notices")
+        summary.fail(check_name, "missing")
+        return False
+
+    print(f"    Bundled JavaScript license notices present ({matches[0]})")
+    summary.pass_(check_name, matches[0])
+    return True
+
+
 def verify_artifact_contents(
     artifacts_dir: str, summary: VerificationSummary | None = None
 ) -> bool:
@@ -455,6 +479,8 @@ def verify_artifact_contents(
                 expected_files,
                 summary,
             ):
+                all_valid = False
+            if not _verify_bundled_js_license(artifact_name, file_bytes, summary):
                 all_valid = False
         else:
             print(f"    ⚠️  Skipping unsupported artifact type: {artifact_name}")

--- a/scripts/verify_apache_artifacts.py
+++ b/scripts/verify_apache_artifacts.py
@@ -60,9 +60,8 @@ from pathlib import Path, PurePosixPath
 # Configuration
 PROJECT_SHORT_NAME = "burr"
 REQUIRED_TEXT_FILES = ("LICENSE", "NOTICE", "DISCLAIMER")
-WHEEL_LICENSE_FILES = ("LICENSE-wheel",)
+WHEEL_LICENSE_FILES = ("LICENSE-wheel", "LICENSE-bundled-js")
 WHEEL_REQUIRED_TEXT_FILES = ("NOTICE", "DISCLAIMER") + WHEEL_LICENSE_FILES
-WHEEL_JS_LICENSE_SUFFIX = ".js.LICENSE.txt"
 PASS = "PASS"
 FAIL = "FAIL"
 SKIP = "SKIP"
@@ -412,29 +411,6 @@ def _verify_required_text_files(
     return all_valid
 
 
-def _verify_bundled_js_license(
-    artifact_name: str,
-    file_bytes: dict[str, bytes],
-    summary: VerificationSummary,
-) -> bool:
-    check_name = f"{artifact_name} contains bundled JavaScript licenses"
-    matches = [
-        path
-        for path in file_bytes
-        if any(part.endswith(".dist-info") for part in PurePosixPath(path).parts)
-        and "/licenses/burr/tracking/server/build/static/js/" in f"/{path}"
-        and path.endswith(WHEEL_JS_LICENSE_SUFFIX)
-    ]
-    if not matches:
-        print("    Missing bundled JavaScript license notices")
-        summary.fail(check_name, "missing")
-        return False
-
-    print(f"    Bundled JavaScript license notices present ({matches[0]})")
-    summary.pass_(check_name, matches[0])
-    return True
-
-
 def verify_artifact_contents(
     artifacts_dir: str, summary: VerificationSummary | None = None
 ) -> bool:
@@ -479,8 +455,6 @@ def verify_artifact_contents(
                 expected_files,
                 summary,
             ):
-                all_valid = False
-            if not _verify_bundled_js_license(artifact_name, file_bytes, summary):
                 all_valid = False
         else:
             print(f"    ⚠️  Skipping unsupported artifact type: {artifact_name}")

--- a/tests/test_verify_apache_artifacts.py
+++ b/tests/test_verify_apache_artifacts.py
@@ -86,6 +86,8 @@ def test_verify_artifact_contents_passes_for_tarball_and_wheel():
                 "apache_burr-0.41.0.dist-info/licenses/LICENSE-wheel": _reference_text(
                     "LICENSE-wheel"
                 ),
+                "apache_burr-0.41.0.dist-info/licenses/burr/tracking/server/build/static/js/"
+                "main.abc123.js.LICENSE.txt": b"third-party notices",
             },
         )
 
@@ -115,6 +117,35 @@ def test_verify_artifact_contents_fails_when_wheel_license_file_is_missing():
         assert verify.verify_artifact_contents(str(artifacts_dir), summary) is False
         assert any(
             result.name.endswith("contains LICENSE-wheel") and result.status == verify.FAIL
+            for result in summary.results
+        )
+
+
+def test_verify_artifact_contents_fails_when_bundled_js_license_is_missing():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        artifacts_dir = Path(temp_dir) / "dist"
+        artifacts_dir.mkdir()
+
+        wheel_path = artifacts_dir / "apache_burr-0.41.0-py3-none-any.whl"
+        _write_wheel(
+            wheel_path,
+            {
+                "apache_burr/__init__.py": b"__version__ = '0.41.0'\n",
+                "apache_burr-0.41.0.dist-info/METADATA": b"Metadata-Version: 2.1\n",
+                "apache_burr-0.41.0.dist-info/WHEEL": b"Wheel-Version: 1.0\n",
+                "apache_burr-0.41.0.dist-info/licenses/NOTICE": _reference_text("NOTICE"),
+                "apache_burr-0.41.0.dist-info/licenses/DISCLAIMER": _reference_text("DISCLAIMER"),
+                "apache_burr-0.41.0.dist-info/licenses/LICENSE-wheel": _reference_text(
+                    "LICENSE-wheel"
+                ),
+            },
+        )
+
+        summary = verify.VerificationSummary()
+        assert verify.verify_artifact_contents(str(artifacts_dir), summary) is False
+        assert any(
+            result.name.endswith("contains bundled JavaScript licenses")
+            and result.status == verify.FAIL
             for result in summary.results
         )
 

--- a/tests/test_verify_apache_artifacts.py
+++ b/tests/test_verify_apache_artifacts.py
@@ -86,8 +86,9 @@ def test_verify_artifact_contents_passes_for_tarball_and_wheel():
                 "apache_burr-0.41.0.dist-info/licenses/LICENSE-wheel": _reference_text(
                     "LICENSE-wheel"
                 ),
-                "apache_burr-0.41.0.dist-info/licenses/burr/tracking/server/build/static/js/"
-                "main.abc123.js.LICENSE.txt": b"third-party notices",
+                "apache_burr-0.41.0.dist-info/licenses/LICENSE-bundled-js": _reference_text(
+                    "LICENSE-bundled-js"
+                ),
             },
         )
 
@@ -117,35 +118,6 @@ def test_verify_artifact_contents_fails_when_wheel_license_file_is_missing():
         assert verify.verify_artifact_contents(str(artifacts_dir), summary) is False
         assert any(
             result.name.endswith("contains LICENSE-wheel") and result.status == verify.FAIL
-            for result in summary.results
-        )
-
-
-def test_verify_artifact_contents_fails_when_bundled_js_license_is_missing():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        artifacts_dir = Path(temp_dir) / "dist"
-        artifacts_dir.mkdir()
-
-        wheel_path = artifacts_dir / "apache_burr-0.41.0-py3-none-any.whl"
-        _write_wheel(
-            wheel_path,
-            {
-                "apache_burr/__init__.py": b"__version__ = '0.41.0'\n",
-                "apache_burr-0.41.0.dist-info/METADATA": b"Metadata-Version: 2.1\n",
-                "apache_burr-0.41.0.dist-info/WHEEL": b"Wheel-Version: 1.0\n",
-                "apache_burr-0.41.0.dist-info/licenses/NOTICE": _reference_text("NOTICE"),
-                "apache_burr-0.41.0.dist-info/licenses/DISCLAIMER": _reference_text("DISCLAIMER"),
-                "apache_burr-0.41.0.dist-info/licenses/LICENSE-wheel": _reference_text(
-                    "LICENSE-wheel"
-                ),
-            },
-        )
-
-        summary = verify.VerificationSummary()
-        assert verify.verify_artifact_contents(str(artifacts_dir), summary) is False
-        assert any(
-            result.name.endswith("contains bundled JavaScript licenses")
-            and result.status == verify.FAIL
             for result in summary.results
         )
 


### PR DESCRIPTION
Surfaces webpack-generated third-party JavaScript notices in the wheel's standard license directory, so consumers do not have to discover them inside package data.

## Changes

- include `main.*.js.LICENSE.txt` through PEP 639 `license-files`
- point wheel consumers to the bundled notices from `LICENSE-wheel`
- fail release artifact verification when the notices are absent

## How I tested this

- `python -m pytest tests/test_verify_apache_artifacts.py tests/test_release_config.py` (20 passed)
- built a wheel with Flit and inspected it to confirm the notice appears under `.dist-info/licenses/burr/tracking/server/build/static/js/`

## Notes

Closes #756.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal
- [x] Relevant checks and tests pass
- [x] The functionality change is tested
- [x] New helper behavior is self-describing and covered by tests
- [x] No placeholder code was added
- [x] License documentation was updated