### PR TITLE
Remove bentoburr

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "examples/deployment/bentoml/BentoBurr"]
-	path = examples/deployment/bentoml/BentoBurr
-	url = https://github.com/bentoml/BentoBurr

--- a/docs/examples/deployment/infrastructure.rst
+++ b/docs/examples/deployment/infrastructure.rst
@@ -25,11 +25,3 @@ Burr is not opinionated about the method of deployment/cloud one uses. Any metho
 (AWS, vercel, etc...). Note we aim to have more examples here -- see `this issue <https://github.com/apache/burr/issues/390>`_ to track!
 
 - `Deploying Burr in an AWS lambda function <https://github.com/apache/burr/tree/main/examples/deployment/aws/lambda>`_
-- `Deploying Burr using BentoML <https://github.com/apache/burr/tree/main/examples/deployment/aws/bentoml>`_
-
-
-Using BentoML
--------------
-`BentoML <https://github.com/bentoml/BentoML>`_ is a specialized tool to package, deploy, and manage AI services.
-For example, it allows you to create a REST API for your Burr application with minimal effort.
-See the `Burr + BentoML example <https://github.com/apache/burr/tree/main/examples/deployment/aws/bentoml>`_ for more information.

--- a/docs/examples/deployment/web-server.rst
+++ b/docs/examples/deployment/web-server.rst
@@ -32,7 +32,6 @@ To run Burr in a FastAPI server, see the following examples:
 - `Use typed state with Pydantic + FastAPI <https://github.com/apache/burr/tree/main/examples/typed-state>`_
 - `Burr + FastAPI + docker <https://github.com/mdrideout/burr-fastapi-docker-compose>`_ by `Matthew Rideout <https://github.com/mdrideout>`_. This contains a sample web server API + UI + tracking server all bundled in one!
 - `Docker compose + nginx proxy <https://github.com/apache/burr/tree/main/examples/email-assistant#running-the-ui-with-email-server-backend-in-a-docker-container>`_ by `Aditha Kaushik <https://github.com/97k>`_ for the email assistant example, demonstrates running the docker image with the tracking server.
-- `BentoML + Burr <https://github.com/apache/burr/tree/main/examples/deployment/aws/bentoml>`_ for deploying Burr with BentoML as a web-service.
 
 Connecting to a database
 ------------------------


### PR DESCRIPTION
This might just me not being in the loop, but is this still relevant? It drags a lot of things into the release and I am not sure if it is still relevant since upstream is archived.

## Changes
- removed the submodule (we are free of submodules now)
- removed the doc references pointing to it
## How I tested this

## Notes
The BentoBurr submodule pointed to an external example repo (github.com/bentoml/BentoBurr) that was archived read-only in August 2025, and the submodule itself was never initialized in practice — it existed only as a dangling reference that shipped as an empty directory plus a stale .gitmodules entry in the ASF source release tarball. The accompanying docs links were broken from the start, pointing to examples/deployment/aws/bentoml, a path that never existed in the repo. Since Burr has no code-level BentoML integration (the example lived entirely upstream), removing the submodule, .gitmodules, and the two doc mentions drops dead weight with no loss of functionality.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
