### PR TITLE
Use UTF-8 for test case JSON files

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -477,14 +477,14 @@ def create_test_case(
     if target_file_name:
         # if it already exists, load it up and append to it
         if os.path.exists(target_file_name):
-            with open(target_file_name, "r") as f:
+            with open(target_file_name, "r", encoding="utf-8") as f:
                 # assumes it's a list of test cases
                 current_testcases = json.load(f)
             current_testcases.append(tc_json)
         else:
             current_testcases = [tc_json]
         print(f"\nWriting data to file {target_file_name}")
-        with open(target_file_name, "w") as f:
+        with open(target_file_name, "w", encoding="utf-8") as f:
             json.dump(current_testcases, f, indent=2)
     else:
         logger.info(json.dumps(tc_json, indent=2))

--- a/burr/lifecycle/default.py
+++ b/burr/lifecycle/default.py
@@ -51,7 +51,7 @@ class StateAndResultsFullLogger(PostRunStepHook, PreRunStepHook):
             raise ValueError(f"jsonl_path must end with .jsonl. Got: {jsonl_path}")
         self.jsonl_path = jsonl_path
         open_mode = "a" if mode == "append" else "w"
-        self.f = open(jsonl_path, mode=open_mode)  # open in append mode
+        self.f = open(jsonl_path, mode=open_mode, encoding="utf-8")
         self.tracker = []  # tracker to keep track of timing/whatnot
         self.json_dump = json_dump
 

--- a/burr/testing/__init__.py
+++ b/burr/testing/__init__.py
@@ -26,7 +26,7 @@ import json
 # and then load it for the test.
 def load_test_cases(file_name: str) -> tuple:
     """Load test cases from a json file."""
-    with open(file_name, "r") as f:
+    with open(file_name, "r", encoding="utf-8") as f:
         json_test_cases = json.load(f)
         test_cases = [(tc.get("input_state"), tc.get("expected_state")) for tc in json_test_cases]
         test_ids = [


### PR DESCRIPTION
## Problem
A few Burr test-case JSON helpers still rely on the platform default text encoding when reading or writing JSON/JSONL files. That can make generated test fixtures or lifecycle logs less portable on systems where the default encoding is not UTF-8.

## Before / after
Before, burr test-case create, load_test_cases(), and StateAndResultsFullLogger opened text JSON files without an explicit encoding.

After, those reads/writes use encoding="utf-8", matching the rest of Burr's text-file handling and keeping non-ASCII fixture/log content deterministic across platforms.

## Verification
- python -m py_compile burr\cli\__main__.py burr\lifecycle\default.py burr\testing\__init__.py
- Ran a small local smoke check that writes/loads a UTF-8 JSON test case and writes UTF-8 JSONL content through StateAndResultsFullLogger.
