### PR TITLE
Fix configured S3 database initialization path

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -96,7 +96,9 @@ jobs:
 
       - name: Run S3 tracking server tests
         run: |
-          python -m pytest tests/tracking/test_bip0042_s3_buffering.py -v
+          python -m pytest \
+            tests/tracking/test_bip0042_s3_buffering.py \
+            tests/tracking/test_s3_initialize_db.py -v
 
   test-bedrock:
     runs-on: ubuntu-latest

--- a/tests/tracking/test_s3_initialize_db.py
+++ b/tests/tracking/test_s3_initialize_db.py
@@ -15,28 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pathlib import Path
+import asyncio
+from unittest.mock import AsyncMock
 
-from tortoise import Tortoise, run_async
-
-from burr.tracking.server.s3 import settings
-
-
-async def connect():
-    db_path = Path(settings.DB_PATH).expanduser()
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    await Tortoise.init(
-        config=settings.TORTOISE_ORM,
-    )
+from burr.tracking.server.s3 import initialize_db, settings
 
 
-#
-async def first_time_init():
-    await connect()
-    # Generate the schema
-    await Tortoise.generate_schemas()
+def test_connect_uses_configured_database_path(tmp_path, monkeypatch):
+    db_path = tmp_path / "nested" / "custom.sqlite3"
+    tortoise_config = {"connections": {"default": f"sqlite:///{db_path}"}, "apps": {}}
+    tortoise_init = AsyncMock()
+    monkeypatch.setattr(settings, "DB_PATH", str(db_path))
+    monkeypatch.setattr(settings, "TORTOISE_ORM", tortoise_config)
+    monkeypatch.setattr(initialize_db.Tortoise, "init", tortoise_init)
 
+    asyncio.run(initialize_db.connect())
 
-if __name__ == "__main__":
-    # db_path = sys.argv[1]
-    run_async(first_time_init())
+    assert db_path.parent.is_dir()
+    tortoise_init.assert_awaited_once_with(config=tortoise_config)

--- a/tests/tracking/test_s3_initialize_db.py
+++ b/tests/tracking/test_s3_initialize_db.py
@@ -18,6 +18,9 @@
 import asyncio
 from unittest.mock import AsyncMock
 
+import pytest
+
+pytest.importorskip("tortoise")
 from burr.tracking.server.s3 import initialize_db, settings
 
 


### PR DESCRIPTION
## What changed

- remove the hard-coded `~/.burr_server/db.sqlite3` path from the S3 initialization helper
- create the parent directory for `settings.DB_PATH`
- add a regression test using a custom nested database path and Tortoise configuration
- run the new optional-dependency test in the dedicated S3 CI job while allowing the default test job to skip it cleanly

## Why

`settings.py` supports `BURR_SERVER_ROOT` and `BURR_DB_FILENAME`, but `initialize_db.py` independently hard-coded the default path. As a result, running the initializer could prepare a different database from the one the S3 server was configured to use.

This is intentionally scoped as a prerequisite to #524. It does not choose between Aerich migrations and schema generation as the supported production bootstrap, and it does not claim to resolve the deployment-documentation issue.

## Validation

- dedicated S3 command: `22 passed`
- Black 23.11.0 (`--line-length 100`)
- isort 5.12.0
- Flake8 6.1.0
- workflow YAML parsed successfully
- `git diff --check`

Contributed as a member of the iFLYTEK Astron community.

Related to #524.
