### PR TITLE
Fix class-based typed state actions

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -175,12 +175,14 @@ def _run_function(function: Function, state: State, inputs: Dict[str, Any], name
             "instead...)"
         )
     state_to_use = state.subset(*function.reads)
+    schema = getattr(function, "schema", DEFAULT_SCHEMA)
+    state_to_use = schema.convert_state_before_run(state_to_use)
     function.validate_inputs(inputs)
     if "__context" in inputs or "__tracer" in inputs:
         # potentially need to remap the __context & __tracer variables
         inputs = _remap_dunder_parameters(function.run, inputs, ["__context", "__tracer"])
     result = function.run(state_to_use, **inputs)
-    _validate_result(result, name)
+    _validate_result(result, name, schema)
     return result
 
 
@@ -190,9 +192,11 @@ async def _arun_function(
     """Runs a function, returning the result of running the function.
     Async version of the above."""
     state_to_use = state.subset(*function.reads)
+    schema = getattr(function, "schema", DEFAULT_SCHEMA)
+    state_to_use = schema.convert_state_before_run(state_to_use)
     function.validate_inputs(inputs)
     result = await function.run(state_to_use, **inputs)
-    _validate_result(result, name)
+    _validate_result(result, name, schema)
     return result
 
 
@@ -250,7 +254,10 @@ def _run_reducer(reducer: Reducer, state: State, result: dict, name: str) -> Sta
     :return:
     """
     # TODO -- better guarding on state reads/writes
-    new_state = reducer.update(result, state)
+    schema = getattr(reducer, "schema", DEFAULT_SCHEMA)
+    state_to_use = schema.convert_state_before_update(state)
+    new_state = reducer.update(result, state_to_use)
+    new_state = schema.convert_state_after_update(new_state, state)
     keys_in_new_state = set(new_state.keys())
     new_keys = keys_in_new_state - set(state.keys())
     extra_keys = new_keys - set(reducer.writes)

--- a/burr/core/typing.py
+++ b/burr/core/typing.py
@@ -126,6 +126,21 @@ class ActionSchema(
     def intermediate_result_type() -> Type[IntermediateResultType]:
         pass
 
+    def convert_state_before_run(self, state: State) -> StateInputType:
+        """Convert Burr state into the value passed to ``Action.run``."""
+        return state  # type: ignore[return-value]
+
+    def convert_state_before_update(self, state: State) -> StateOutputType:
+        """Convert Burr state into the value passed to ``Action.update``."""
+        return state  # type: ignore[return-value]
+
+    def convert_state_after_update(
+        self, state: StateOutputType, original_state: State
+    ) -> State:
+        """Convert the value returned by ``Action.update`` back to Burr state."""
+        return state  # type: ignore[return-value]
+
+
 
 class DictBasedTypingSystem(TypingSystem[dict]):
     """Effectively a no-op. State is backed by a dictionary, which allows every state item

--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -188,6 +188,26 @@ class PydanticActionSchema(ActionSchema[StateInputType, StateOutputType, Interme
     def intermediate_result_type(self) -> type[IntermediateResultType]:
         return self._intermediate_result_type
 
+    def convert_state_before_run(self, state: State) -> StateInputType:
+        return model_from_state(model=self._input_type, state=state)
+
+    def convert_state_before_update(self, state: State) -> StateOutputType:
+        return model_from_state(model=self._output_type, state=state)
+
+    def convert_state_after_update(
+        self, state: StateOutputType, original_state: State
+    ) -> State:
+        if not isinstance(state, self._output_type):
+            raise TypeError(
+                f"Expected update() to return {self._output_type.__name__}, "
+                f"got {type(state).__name__}."
+            )
+        return merge_to_state(
+            model=state,
+            write_keys=list(self._output_type.model_fields),
+            state=original_state,
+        )
+
 
 def pydantic_action(
     reads: List[str],

--- a/tests/integrations/test_class_based_pydantic.py
+++ b/tests/integrations/test_class_based_pydantic.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+from burr.core.action import Action
+from burr.core.application import ApplicationBuilder
+from burr.integrations.pydantic import PydanticActionSchema, PydanticTypingSystem
+
+
+class ClassBasedState(BaseModel):
+    initial_prompt: Optional[str] = None
+    observed_prompt: Optional[str] = None
+
+
+class SetInitialPromptAction(Action):
+    @property
+    def reads(self) -> list[str]:
+        return []
+
+    @property
+    def writes(self) -> list[str]:
+        return ["initial_prompt"]
+
+    @property
+    def inputs(self) -> list[str]:
+        return ["prompt"]
+
+    @property
+    def schema(self) -> PydanticActionSchema:
+        return PydanticActionSchema(ClassBasedState, ClassBasedState, dict)
+
+    def run(self, state: ClassBasedState, prompt: str) -> dict:
+        assert isinstance(state, ClassBasedState)
+        return {"initial_prompt": prompt}
+
+    def update(self, result: dict, state: ClassBasedState) -> ClassBasedState:
+        assert isinstance(state, ClassBasedState)
+        state.initial_prompt = result["initial_prompt"]
+        return state
+
+
+class ObservePromptAction(Action):
+    @property
+    def reads(self) -> list[str]:
+        return ["initial_prompt"]
+
+    @property
+    def writes(self) -> list[str]:
+        return ["observed_prompt"]
+
+    @property
+    def schema(self) -> PydanticActionSchema:
+        return PydanticActionSchema(ClassBasedState, ClassBasedState, dict)
+
+    def run(self, state: ClassBasedState) -> dict:
+        assert isinstance(state, ClassBasedState)
+        return {"observed_prompt": state.initial_prompt}
+
+    def update(self, result: dict, state: ClassBasedState) -> ClassBasedState:
+        assert isinstance(state, ClassBasedState)
+        state.observed_prompt = result["observed_prompt"]
+        return state
+
+
+class AsyncObservePromptAction(ObservePromptAction):
+    async def run(self, state: ClassBasedState) -> dict:
+        assert isinstance(state, ClassBasedState)
+        return {"observed_prompt": state.initial_prompt}
+
+
+def build_class_based_app(observe: Action):
+    return (
+        ApplicationBuilder()
+        .with_actions(set_prompt=SetInitialPromptAction(), observe=observe)
+        .with_entrypoint("set_prompt")
+        .with_transitions(("set_prompt", "observe"))
+        .with_typing(PydanticTypingSystem(ClassBasedState))
+        .with_state(ClassBasedState())
+        .build()
+    )
+
+
+def test_class_based_actions_receive_pydantic_state():
+    app = build_class_based_app(ObservePromptAction())
+
+    _, _, state = app.run(halt_after=["observe"], inputs={"prompt": "typed state"})
+
+    assert isinstance(state.data, ClassBasedState)
+    assert state.data.initial_prompt == "typed state"
+    assert state.data.observed_prompt == "typed state"
+
+
+async def test_async_class_based_action_receives_pydantic_state():
+    app = build_class_based_app(AsyncObservePromptAction())
+    _, _, state = await app.arun(
+        halt_after=["observe"], inputs={"prompt": "typed state"}
+    )
+
+    assert isinstance(state.data, ClassBasedState)
+    assert state.data.initial_prompt == "typed state"
+    assert state.data.observed_prompt == "typed state"


### PR DESCRIPTION
## Summary

- add identity state-conversion hooks to `ActionSchema`
- let `PydanticActionSchema` convert Burr `State` values into its input/output models and merge typed updates back into the original state
- apply schema conversion in synchronous and asynchronous class-based `Action` execution
- preserve existing `Function`/`Reducer` behavior through `DEFAULT_SCHEMA` fallback
- add end-to-end sync and async class-based Pydantic regression tests

## Root cause

Class-based actions could expose an `ActionSchema`, but the application lifecycle only used it to validate intermediate result types. `run()` and `update()` still received Burr `State` objects, so model attribute access such as `state.initial_prompt` failed even with a Pydantic schema.

## Impact

Class-based actions that expose `PydanticActionSchema` now receive the declared Pydantic input/output models. The typed model returned from `update()` is merged into the original Burr state, preserving unrelated fields and the application typing system. Existing dict-based actions and schema-less internal reducers keep their current behavior.

## Validation

- `python -m pytest tests\core\test_application.py tests\core\test_action.py tests\integrations\test_class_based_pydantic.py tests\integrations\test_burr_pydantic.py -q` 鈥?326 passed
- `python -m ruff check burr\core\typing.py burr\core\application.py burr\integrations\pydantic.py tests\integrations\test_class_based_pydantic.py`
- `python -m black --check tests\integrations\test_class_based_pydantic.py`
- `git diff --check`

Closes #400.

Contributed as a member of the iFLYTEK Astron community.
