### PR TITLE
fix(testing): read test case json as utf-8

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -477,14 +477,14 @@ def create_test_case(
     if target_file_name:
         # if it already exists, load it up and append to it
         if os.path.exists(target_file_name):
-            with open(target_file_name, "r") as f:
+            with open(target_file_name, "r", encoding="utf-8") as f:
                 # assumes it's a list of test cases
                 current_testcases = json.load(f)
             current_testcases.append(tc_json)
         else:
             current_testcases = [tc_json]
         print(f"\nWriting data to file {target_file_name}")
-        with open(target_file_name, "w") as f:
+        with open(target_file_name, "w", encoding="utf-8") as f:
             json.dump(current_testcases, f, indent=2)
     else:
         logger.info(json.dumps(tc_json, indent=2))

--- a/burr/testing/__init__.py
+++ b/burr/testing/__init__.py
@@ -26,7 +26,7 @@ import json
 # and then load it for the test.
 def load_test_cases(file_name: str) -> tuple:
     """Load test cases from a json file."""
-    with open(file_name, "r") as f:
+    with open(file_name, "r", encoding="utf-8") as f:
         json_test_cases = json.load(f)
         test_cases = [(tc.get("input_state"), tc.get("expected_state")) for tc in json_test_cases]
         test_ids = [

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+
+from burr.testing import load_test_cases
+
+
+def test_load_test_cases_reads_utf8_json(tmp_path):
+    test_case_file = tmp_path / "test_cases.json"
+    test_case_file.write_text(
+        json.dumps(
+            [
+                {
+                    "action": "summarize",
+                    "name": "handles_utf8",
+                    "input_state": {"message": "café"},
+                    "expected_state": {"response": "résumé"},
+                }
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    test_cases, test_ids = load_test_cases(str(test_case_file))
+
+    assert test_cases == [({"message": "café"}, {"response": "résumé"})]
+    assert test_ids == ["summarize-handles_utf8"]


### PR DESCRIPTION
## Problem

Burr's generated pytest test-case JSON path used the platform default encoding when appending fixtures from `burr test-case create` and when loading those fixtures through `burr.testing.load_test_cases()`.

Those JSON files can contain serialized application state, prompts, responses, or user text. On systems whose default encoding is not UTF-8, fixtures with non-ASCII text can fail to load or be interpreted inconsistently.

## Before / after

Before, the CLI writer and pytest helper opened test-case JSON files without specifying an encoding.

After, both the generated fixture writer and `load_test_cases()` read/write those JSON files with `encoding="utf-8"`. A focused regression test writes a UTF-8 JSON fixture with literal non-ASCII text and verifies it loads with the expected test id and state payloads.

## Verification

- `python -m pytest tests/test_testing.py tests/integrations/test_burr_pydantic_future_annotations.py`
- `git diff --check`